### PR TITLE
fix return description for getUnderlyingPrice

### DIFF
--- a/contracts/Uniswap/UniswapAnchoredView.sol
+++ b/contracts/Uniswap/UniswapAnchoredView.sol
@@ -131,7 +131,7 @@ contract UniswapAnchoredView is AggregatorValidatorInterface, UniswapConfig, Own
      * @notice Get the underlying price of a cToken, in the format expected by the Comptroller.
      * @dev Implements the PriceOracle interface for Compound v2.
      * @param cToken The cToken address for price retrieval
-     * @return 18 decimal fixed point mantissa of the USD price for the given cToken address
+     * @return Price denominated in USD for the given cToken address, in the format expected by the Comptroller.
      */
     function getUnderlyingPrice(address cToken) external view returns (uint) {
         TokenConfig memory config = getTokenConfigByCToken(cToken);

--- a/contracts/Uniswap/UniswapAnchoredView.sol
+++ b/contracts/Uniswap/UniswapAnchoredView.sol
@@ -128,10 +128,10 @@ contract UniswapAnchoredView is AggregatorValidatorInterface, UniswapConfig, Own
     }
 
     /**
-     * @notice Get the underlying price of a cToken
+     * @notice Get the underlying price of a cToken, in the format expected by the Comptroller.
      * @dev Implements the PriceOracle interface for Compound v2.
      * @param cToken The cToken address for price retrieval
-     * @return Price denominated in USD, with 18 decimals, for the given cToken address
+     * @return 18 decimal fixed point mantissa of the USD price for the given cToken address
      */
     function getUnderlyingPrice(address cToken) external view returns (uint) {
         TokenConfig memory config = getTokenConfigByCToken(cToken);


### PR DESCRIPTION
The documentation for getUnderlyingPrice does not reflect what it actually does.

Example:
With USDC, we have `baseUnit = 1e6`. Thus `getUnderlyingPrice` returns `1e30 * 1e6 / 1e6 = 1e30`.
With USDP, we have `baseUnit = 1e18`. Thus `getUnderlyingPrice` returns `1e30 * 1e6 / 1e18 = 1e18`.