### PR TITLE
Fetch underlying price using ctoken

### DIFF
--- a/contracts/Uniswap/UniswapAnchoredView.sol
+++ b/contracts/Uniswap/UniswapAnchoredView.sol
@@ -134,9 +134,7 @@ contract UniswapAnchoredView is
         view
         returns (uint256)
     {
-        TokenConfig memory config = getTokenConfigByUnderlying(
-            CErc20(cToken).underlying()
-        );
+        TokenConfig memory config = getTokenConfigByCToken(cToken);
         // Comptroller needs prices in the format: ${raw price} * 1e36 / baseUnit
         // The baseUnit of an asset is the amount of the smallest denomination of that asset per whole.
         // For example, the baseUnit of ETH is 1e18.

--- a/contracts/Uniswap/UniswapConfig.sol
+++ b/contracts/Uniswap/UniswapConfig.sol
@@ -2,8 +2,6 @@
 
 pragma solidity =0.8.7;
 
-import {CErc20} from "./CErc20.sol";
-
 contract UniswapConfig {
     /// @notice The maximum integer possible
     uint256 public constant MAX_INTEGER = type(uint256).max;
@@ -1194,7 +1192,6 @@ contract UniswapConfig {
 
     /**
      * @notice Get the config for the cToken
-     * @dev If a config for the cToken is not found, falls back to searching for the underlying.
      * @param cToken The address of the cToken of the config to get
      * @return The config object
      */
@@ -1203,8 +1200,7 @@ contract UniswapConfig {
         view
         returns (TokenConfig memory)
     {
-        uint256 index = getCTokenIndex(cToken);
-        return getTokenConfig(index);
+        return getTokenConfig(getCTokenIndex(cToken));
     }
 
     /**

--- a/contracts/Uniswap/UniswapConfig.sol
+++ b/contracts/Uniswap/UniswapConfig.sol
@@ -18,6 +18,8 @@ contract UniswapConfig {
     /// @dev Describe how the USD price should be determined for an asset.
     ///  There should be 1 TokenConfig object for each supported asset, passed in the constructor.
     struct TokenConfig {
+        // The address of the Compound Token
+        address cToken;
         // The address of the underlying market token. For this `LINK` market configuration, this would be the address of the `LINK` token.
         address underlying;
         // The bytes32 hash of the underlying symbol.
@@ -44,6 +46,42 @@ contract UniswapConfig {
 
     /// @notice The number of tokens this contract actually supports
     uint256 public immutable numTokens;
+
+    address internal immutable cToken00;
+    address internal immutable cToken01;
+    address internal immutable cToken02;
+    address internal immutable cToken03;
+    address internal immutable cToken04;
+    address internal immutable cToken05;
+    address internal immutable cToken06;
+    address internal immutable cToken07;
+    address internal immutable cToken08;
+    address internal immutable cToken09;
+    address internal immutable cToken10;
+    address internal immutable cToken11;
+    address internal immutable cToken12;
+    address internal immutable cToken13;
+    address internal immutable cToken14;
+    address internal immutable cToken15;
+    address internal immutable cToken16;
+    address internal immutable cToken17;
+    address internal immutable cToken18;
+    address internal immutable cToken19;
+    address internal immutable cToken20;
+    address internal immutable cToken21;
+    address internal immutable cToken22;
+    address internal immutable cToken23;
+    address internal immutable cToken24;
+    address internal immutable cToken25;
+    address internal immutable cToken26;
+    address internal immutable cToken27;
+    address internal immutable cToken28;
+    address internal immutable cToken29;
+    address internal immutable cToken30;
+    address internal immutable cToken31;
+    address internal immutable cToken32;
+    address internal immutable cToken33;
+    address internal immutable cToken34;
 
     address internal immutable underlying00;
     address internal immutable underlying01;
@@ -346,6 +384,7 @@ contract UniswapConfig {
         numTokens = configs.length;
 
         TokenConfig memory config = get(configs, 0);
+        cToken00 = config.cToken;
         underlying00 = config.underlying;
         symbolHash00 = config.symbolHash;
         baseUnit00 = config.baseUnit;
@@ -356,6 +395,7 @@ contract UniswapConfig {
         reporterMultiplier00 = config.reporterMultiplier;
 
         config = get(configs, 1);
+        cToken01 = config.cToken;
         underlying01 = config.underlying;
         symbolHash01 = config.symbolHash;
         baseUnit01 = config.baseUnit;
@@ -366,6 +406,7 @@ contract UniswapConfig {
         reporterMultiplier01 = config.reporterMultiplier;
 
         config = get(configs, 2);
+        cToken02 = config.cToken;
         underlying02 = config.underlying;
         symbolHash02 = config.symbolHash;
         baseUnit02 = config.baseUnit;
@@ -376,6 +417,7 @@ contract UniswapConfig {
         reporterMultiplier02 = config.reporterMultiplier;
 
         config = get(configs, 3);
+        cToken03 = config.cToken;
         underlying03 = config.underlying;
         symbolHash03 = config.symbolHash;
         baseUnit03 = config.baseUnit;
@@ -386,6 +428,7 @@ contract UniswapConfig {
         reporterMultiplier03 = config.reporterMultiplier;
 
         config = get(configs, 4);
+        cToken04 = config.cToken;
         underlying04 = config.underlying;
         symbolHash04 = config.symbolHash;
         baseUnit04 = config.baseUnit;
@@ -396,6 +439,7 @@ contract UniswapConfig {
         reporterMultiplier04 = config.reporterMultiplier;
 
         config = get(configs, 5);
+        cToken05 = config.cToken;
         underlying05 = config.underlying;
         symbolHash05 = config.symbolHash;
         baseUnit05 = config.baseUnit;
@@ -406,6 +450,7 @@ contract UniswapConfig {
         reporterMultiplier05 = config.reporterMultiplier;
 
         config = get(configs, 6);
+        cToken06 = config.cToken;
         underlying06 = config.underlying;
         symbolHash06 = config.symbolHash;
         baseUnit06 = config.baseUnit;
@@ -416,6 +461,7 @@ contract UniswapConfig {
         reporterMultiplier06 = config.reporterMultiplier;
 
         config = get(configs, 7);
+        cToken07 = config.cToken;
         underlying07 = config.underlying;
         symbolHash07 = config.symbolHash;
         baseUnit07 = config.baseUnit;
@@ -426,6 +472,7 @@ contract UniswapConfig {
         reporterMultiplier07 = config.reporterMultiplier;
 
         config = get(configs, 8);
+        cToken08 = config.cToken;
         underlying08 = config.underlying;
         symbolHash08 = config.symbolHash;
         baseUnit08 = config.baseUnit;
@@ -436,6 +483,7 @@ contract UniswapConfig {
         reporterMultiplier08 = config.reporterMultiplier;
 
         config = get(configs, 9);
+        cToken09 = config.cToken;
         underlying09 = config.underlying;
         symbolHash09 = config.symbolHash;
         baseUnit09 = config.baseUnit;
@@ -446,6 +494,7 @@ contract UniswapConfig {
         reporterMultiplier09 = config.reporterMultiplier;
 
         config = get(configs, 10);
+        cToken10 = config.cToken;
         underlying10 = config.underlying;
         symbolHash10 = config.symbolHash;
         baseUnit10 = config.baseUnit;
@@ -456,6 +505,7 @@ contract UniswapConfig {
         reporterMultiplier10 = config.reporterMultiplier;
 
         config = get(configs, 11);
+        cToken11 = config.cToken;
         underlying11 = config.underlying;
         symbolHash11 = config.symbolHash;
         baseUnit11 = config.baseUnit;
@@ -466,6 +516,7 @@ contract UniswapConfig {
         reporterMultiplier11 = config.reporterMultiplier;
 
         config = get(configs, 12);
+        cToken12 = config.cToken;
         underlying12 = config.underlying;
         symbolHash12 = config.symbolHash;
         baseUnit12 = config.baseUnit;
@@ -476,6 +527,7 @@ contract UniswapConfig {
         reporterMultiplier12 = config.reporterMultiplier;
 
         config = get(configs, 13);
+        cToken13 = config.cToken;
         underlying13 = config.underlying;
         symbolHash13 = config.symbolHash;
         baseUnit13 = config.baseUnit;
@@ -486,6 +538,7 @@ contract UniswapConfig {
         reporterMultiplier13 = config.reporterMultiplier;
 
         config = get(configs, 14);
+        cToken14 = config.cToken;
         underlying14 = config.underlying;
         symbolHash14 = config.symbolHash;
         baseUnit14 = config.baseUnit;
@@ -496,6 +549,7 @@ contract UniswapConfig {
         reporterMultiplier14 = config.reporterMultiplier;
 
         config = get(configs, 15);
+        cToken15 = config.cToken;
         underlying15 = config.underlying;
         symbolHash15 = config.symbolHash;
         baseUnit15 = config.baseUnit;
@@ -506,6 +560,7 @@ contract UniswapConfig {
         reporterMultiplier15 = config.reporterMultiplier;
 
         config = get(configs, 16);
+        cToken16 = config.cToken;
         underlying16 = config.underlying;
         symbolHash16 = config.symbolHash;
         baseUnit16 = config.baseUnit;
@@ -516,6 +571,7 @@ contract UniswapConfig {
         reporterMultiplier16 = config.reporterMultiplier;
 
         config = get(configs, 17);
+        cToken17 = config.cToken;
         underlying17 = config.underlying;
         symbolHash17 = config.symbolHash;
         baseUnit17 = config.baseUnit;
@@ -526,6 +582,7 @@ contract UniswapConfig {
         reporterMultiplier17 = config.reporterMultiplier;
 
         config = get(configs, 18);
+        cToken18 = config.cToken;
         underlying18 = config.underlying;
         symbolHash18 = config.symbolHash;
         baseUnit18 = config.baseUnit;
@@ -536,6 +593,7 @@ contract UniswapConfig {
         reporterMultiplier18 = config.reporterMultiplier;
 
         config = get(configs, 19);
+        cToken19 = config.cToken;
         underlying19 = config.underlying;
         symbolHash19 = config.symbolHash;
         baseUnit19 = config.baseUnit;
@@ -546,6 +604,7 @@ contract UniswapConfig {
         reporterMultiplier19 = config.reporterMultiplier;
 
         config = get(configs, 20);
+        cToken20 = config.cToken;
         underlying20 = config.underlying;
         symbolHash20 = config.symbolHash;
         baseUnit20 = config.baseUnit;
@@ -556,6 +615,7 @@ contract UniswapConfig {
         reporterMultiplier20 = config.reporterMultiplier;
 
         config = get(configs, 21);
+        cToken21 = config.cToken;
         underlying21 = config.underlying;
         symbolHash21 = config.symbolHash;
         baseUnit21 = config.baseUnit;
@@ -566,6 +626,7 @@ contract UniswapConfig {
         reporterMultiplier21 = config.reporterMultiplier;
 
         config = get(configs, 22);
+        cToken22 = config.cToken;
         underlying22 = config.underlying;
         symbolHash22 = config.symbolHash;
         baseUnit22 = config.baseUnit;
@@ -576,6 +637,7 @@ contract UniswapConfig {
         reporterMultiplier22 = config.reporterMultiplier;
 
         config = get(configs, 23);
+        cToken23 = config.cToken;
         underlying23 = config.underlying;
         symbolHash23 = config.symbolHash;
         baseUnit23 = config.baseUnit;
@@ -586,6 +648,7 @@ contract UniswapConfig {
         reporterMultiplier23 = config.reporterMultiplier;
 
         config = get(configs, 24);
+        cToken24 = config.cToken;
         underlying24 = config.underlying;
         symbolHash24 = config.symbolHash;
         baseUnit24 = config.baseUnit;
@@ -596,6 +659,7 @@ contract UniswapConfig {
         reporterMultiplier24 = config.reporterMultiplier;
 
         config = get(configs, 25);
+        cToken25 = config.cToken;
         underlying25 = config.underlying;
         symbolHash25 = config.symbolHash;
         baseUnit25 = config.baseUnit;
@@ -606,6 +670,7 @@ contract UniswapConfig {
         reporterMultiplier25 = config.reporterMultiplier;
 
         config = get(configs, 26);
+        cToken26 = config.cToken;
         underlying26 = config.underlying;
         symbolHash26 = config.symbolHash;
         baseUnit26 = config.baseUnit;
@@ -616,6 +681,7 @@ contract UniswapConfig {
         reporterMultiplier26 = config.reporterMultiplier;
 
         config = get(configs, 27);
+        cToken27 = config.cToken;
         underlying27 = config.underlying;
         symbolHash27 = config.symbolHash;
         baseUnit27 = config.baseUnit;
@@ -626,6 +692,7 @@ contract UniswapConfig {
         reporterMultiplier27 = config.reporterMultiplier;
 
         config = get(configs, 28);
+        cToken28 = config.cToken;
         underlying28 = config.underlying;
         symbolHash28 = config.symbolHash;
         baseUnit28 = config.baseUnit;
@@ -636,6 +703,7 @@ contract UniswapConfig {
         reporterMultiplier28 = config.reporterMultiplier;
 
         config = get(configs, 29);
+        cToken29 = config.cToken;
         underlying29 = config.underlying;
         symbolHash29 = config.symbolHash;
         baseUnit29 = config.baseUnit;
@@ -646,6 +714,7 @@ contract UniswapConfig {
         reporterMultiplier29 = config.reporterMultiplier;
 
         config = get(configs, 30);
+        cToken30 = config.cToken;
         underlying30 = config.underlying;
         symbolHash30 = config.symbolHash;
         baseUnit30 = config.baseUnit;
@@ -656,6 +725,7 @@ contract UniswapConfig {
         reporterMultiplier30 = config.reporterMultiplier;
 
         config = get(configs, 31);
+        cToken31 = config.cToken;
         underlying31 = config.underlying;
         symbolHash31 = config.symbolHash;
         baseUnit31 = config.baseUnit;
@@ -666,6 +736,7 @@ contract UniswapConfig {
         reporterMultiplier31 = config.reporterMultiplier;
 
         config = get(configs, 32);
+        cToken32 = config.cToken;
         underlying32 = config.underlying;
         symbolHash32 = config.symbolHash;
         baseUnit32 = config.baseUnit;
@@ -676,6 +747,7 @@ contract UniswapConfig {
         reporterMultiplier32 = config.reporterMultiplier;
 
         config = get(configs, 33);
+        cToken33 = config.cToken;
         underlying33 = config.underlying;
         symbolHash33 = config.symbolHash;
         baseUnit33 = config.baseUnit;
@@ -686,6 +758,7 @@ contract UniswapConfig {
         reporterMultiplier33 = config.reporterMultiplier;
 
         config = get(configs, 34);
+        cToken34 = config.cToken;
         underlying34 = config.underlying;
         symbolHash34 = config.symbolHash;
         baseUnit34 = config.baseUnit;
@@ -712,6 +785,7 @@ contract UniswapConfig {
         if (i < configs.length) return configs[i];
         return
             TokenConfig({
+                cToken: address(0),
                 underlying: address(0),
                 symbolHash: bytes32(0),
                 baseUnit: uint256(0),
@@ -856,6 +930,46 @@ contract UniswapConfig {
         return type(uint256).max;
     }
 
+    function getCTokenIndex(address cToken) internal view returns (int256) {
+        if (cToken == cToken00) return 0;
+        if (cToken == cToken01) return 1;
+        if (cToken == cToken02) return 2;
+        if (cToken == cToken03) return 3;
+        if (cToken == cToken04) return 4;
+        if (cToken == cToken05) return 5;
+        if (cToken == cToken06) return 6;
+        if (cToken == cToken07) return 7;
+        if (cToken == cToken08) return 8;
+        if (cToken == cToken09) return 9;
+        if (cToken == cToken10) return 10;
+        if (cToken == cToken11) return 11;
+        if (cToken == cToken12) return 12;
+        if (cToken == cToken13) return 13;
+        if (cToken == cToken14) return 14;
+        if (cToken == cToken15) return 15;
+        if (cToken == cToken16) return 16;
+        if (cToken == cToken17) return 17;
+        if (cToken == cToken18) return 18;
+        if (cToken == cToken19) return 19;
+        if (cToken == cToken20) return 20;
+        if (cToken == cToken21) return 21;
+        if (cToken == cToken22) return 22;
+        if (cToken == cToken23) return 23;
+        if (cToken == cToken24) return 24;
+        if (cToken == cToken25) return 25;
+        if (cToken == cToken26) return 26;
+        if (cToken == cToken27) return 27;
+        if (cToken == cToken28) return 28;
+        if (cToken == cToken29) return 29;
+        if (cToken == cToken30) return 30;
+        if (cToken == cToken31) return 31;
+        if (cToken == cToken32) return 32;
+        if (cToken == cToken33) return 33;
+        if (cToken == cToken34) return 34;
+
+        return -1;
+    }
+
     /**
      * @notice Get the i-th config, according to the order they were passed in originally
      * @param i The index of the config to get
@@ -868,6 +982,7 @@ contract UniswapConfig {
     {
         require(i < numTokens, "Not found");
 
+        address cToken;
         address underlying;
         bytes32 symbolHash;
         uint256 baseUnit;
@@ -877,6 +992,7 @@ contract UniswapConfig {
         address reporter;
         uint256 reporterMultiplier;
         if (i == 0) {
+            cToken = cToken00;
             underlying = underlying00;
             symbolHash = symbolHash00;
             baseUnit = baseUnit00;
@@ -886,6 +1002,7 @@ contract UniswapConfig {
             reporter = reporter00;
             reporterMultiplier = reporterMultiplier00;
         } else if (i == 1) {
+            cToken = cToken01;
             underlying = underlying01;
             symbolHash = symbolHash01;
             baseUnit = baseUnit01;
@@ -895,6 +1012,7 @@ contract UniswapConfig {
             reporter = reporter01;
             reporterMultiplier = reporterMultiplier01;
         } else if (i == 2) {
+            cToken = cToken02;
             underlying = underlying02;
             symbolHash = symbolHash02;
             baseUnit = baseUnit02;
@@ -904,6 +1022,7 @@ contract UniswapConfig {
             reporter = reporter02;
             reporterMultiplier = reporterMultiplier02;
         } else if (i == 3) {
+            cToken = cToken03;
             underlying = underlying03;
             symbolHash = symbolHash03;
             baseUnit = baseUnit03;
@@ -913,6 +1032,7 @@ contract UniswapConfig {
             reporter = reporter03;
             reporterMultiplier = reporterMultiplier03;
         } else if (i == 4) {
+            cToken = cToken04;
             underlying = underlying04;
             symbolHash = symbolHash04;
             baseUnit = baseUnit04;
@@ -922,6 +1042,7 @@ contract UniswapConfig {
             reporter = reporter04;
             reporterMultiplier = reporterMultiplier04;
         } else if (i == 5) {
+            cToken = cToken05;
             underlying = underlying05;
             symbolHash = symbolHash05;
             baseUnit = baseUnit05;
@@ -931,6 +1052,7 @@ contract UniswapConfig {
             reporter = reporter05;
             reporterMultiplier = reporterMultiplier05;
         } else if (i == 6) {
+            cToken = cToken06;
             underlying = underlying06;
             symbolHash = symbolHash06;
             baseUnit = baseUnit06;
@@ -940,6 +1062,7 @@ contract UniswapConfig {
             reporter = reporter06;
             reporterMultiplier = reporterMultiplier06;
         } else if (i == 7) {
+            cToken = cToken07;
             underlying = underlying07;
             symbolHash = symbolHash07;
             baseUnit = baseUnit07;
@@ -949,6 +1072,7 @@ contract UniswapConfig {
             reporter = reporter07;
             reporterMultiplier = reporterMultiplier07;
         } else if (i == 8) {
+            cToken = cToken08;
             underlying = underlying08;
             symbolHash = symbolHash08;
             baseUnit = baseUnit08;
@@ -958,6 +1082,7 @@ contract UniswapConfig {
             reporter = reporter08;
             reporterMultiplier = reporterMultiplier08;
         } else if (i == 9) {
+            cToken = cToken09;
             underlying = underlying09;
             symbolHash = symbolHash09;
             baseUnit = baseUnit09;
@@ -967,6 +1092,7 @@ contract UniswapConfig {
             reporter = reporter09;
             reporterMultiplier = reporterMultiplier09;
         } else if (i == 10) {
+            cToken = cToken10;
             underlying = underlying10;
             symbolHash = symbolHash10;
             baseUnit = baseUnit10;
@@ -976,6 +1102,7 @@ contract UniswapConfig {
             reporter = reporter10;
             reporterMultiplier = reporterMultiplier10;
         } else if (i == 11) {
+            cToken = cToken11;
             underlying = underlying11;
             symbolHash = symbolHash11;
             baseUnit = baseUnit11;
@@ -985,6 +1112,7 @@ contract UniswapConfig {
             reporter = reporter11;
             reporterMultiplier = reporterMultiplier11;
         } else if (i == 12) {
+            cToken = cToken12;
             underlying = underlying12;
             symbolHash = symbolHash12;
             baseUnit = baseUnit12;
@@ -994,6 +1122,7 @@ contract UniswapConfig {
             reporter = reporter12;
             reporterMultiplier = reporterMultiplier12;
         } else if (i == 13) {
+            cToken = cToken13;
             underlying = underlying13;
             symbolHash = symbolHash13;
             baseUnit = baseUnit13;
@@ -1003,6 +1132,7 @@ contract UniswapConfig {
             reporter = reporter13;
             reporterMultiplier = reporterMultiplier13;
         } else if (i == 14) {
+            cToken = cToken14;
             underlying = underlying14;
             symbolHash = symbolHash14;
             baseUnit = baseUnit14;
@@ -1012,6 +1142,7 @@ contract UniswapConfig {
             reporter = reporter14;
             reporterMultiplier = reporterMultiplier14;
         } else if (i == 15) {
+            cToken = cToken15;
             underlying = underlying15;
             symbolHash = symbolHash15;
             baseUnit = baseUnit15;
@@ -1021,6 +1152,7 @@ contract UniswapConfig {
             reporter = reporter15;
             reporterMultiplier = reporterMultiplier15;
         } else if (i == 16) {
+            cToken = cToken16;
             underlying = underlying16;
             symbolHash = symbolHash16;
             baseUnit = baseUnit16;
@@ -1030,6 +1162,7 @@ contract UniswapConfig {
             reporter = reporter16;
             reporterMultiplier = reporterMultiplier16;
         } else if (i == 17) {
+            cToken = cToken17;
             underlying = underlying17;
             symbolHash = symbolHash17;
             baseUnit = baseUnit17;
@@ -1039,6 +1172,7 @@ contract UniswapConfig {
             reporter = reporter17;
             reporterMultiplier = reporterMultiplier17;
         } else if (i == 18) {
+            cToken = cToken18;
             underlying = underlying18;
             symbolHash = symbolHash18;
             baseUnit = baseUnit18;
@@ -1048,6 +1182,7 @@ contract UniswapConfig {
             reporter = reporter18;
             reporterMultiplier = reporterMultiplier18;
         } else if (i == 19) {
+            cToken = cToken19;
             underlying = underlying19;
             symbolHash = symbolHash19;
             baseUnit = baseUnit19;
@@ -1057,6 +1192,7 @@ contract UniswapConfig {
             reporter = reporter19;
             reporterMultiplier = reporterMultiplier19;
         } else if (i == 20) {
+            cToken = cToken20;
             underlying = underlying20;
             symbolHash = symbolHash20;
             baseUnit = baseUnit20;
@@ -1066,6 +1202,7 @@ contract UniswapConfig {
             reporter = reporter20;
             reporterMultiplier = reporterMultiplier20;
         } else if (i == 21) {
+            cToken = cToken21;
             underlying = underlying21;
             symbolHash = symbolHash21;
             baseUnit = baseUnit21;
@@ -1075,6 +1212,7 @@ contract UniswapConfig {
             reporter = reporter21;
             reporterMultiplier = reporterMultiplier21;
         } else if (i == 22) {
+            cToken = cToken22;
             underlying = underlying22;
             symbolHash = symbolHash22;
             baseUnit = baseUnit22;
@@ -1084,6 +1222,7 @@ contract UniswapConfig {
             reporter = reporter22;
             reporterMultiplier = reporterMultiplier22;
         } else if (i == 23) {
+            cToken = cToken23;
             underlying = underlying23;
             symbolHash = symbolHash23;
             baseUnit = baseUnit23;
@@ -1093,6 +1232,7 @@ contract UniswapConfig {
             reporter = reporter23;
             reporterMultiplier = reporterMultiplier23;
         } else if (i == 24) {
+            cToken = cToken24;
             underlying = underlying24;
             symbolHash = symbolHash24;
             baseUnit = baseUnit24;
@@ -1102,6 +1242,7 @@ contract UniswapConfig {
             reporter = reporter24;
             reporterMultiplier = reporterMultiplier24;
         } else if (i == 25) {
+            cToken = cToken25;
             underlying = underlying25;
             symbolHash = symbolHash25;
             baseUnit = baseUnit25;
@@ -1111,6 +1252,7 @@ contract UniswapConfig {
             reporter = reporter25;
             reporterMultiplier = reporterMultiplier25;
         } else if (i == 26) {
+            cToken = cToken26;
             underlying = underlying26;
             symbolHash = symbolHash26;
             baseUnit = baseUnit26;
@@ -1120,6 +1262,7 @@ contract UniswapConfig {
             reporter = reporter26;
             reporterMultiplier = reporterMultiplier26;
         } else if (i == 27) {
+            cToken = cToken27;
             underlying = underlying27;
             symbolHash = symbolHash27;
             baseUnit = baseUnit27;
@@ -1129,6 +1272,7 @@ contract UniswapConfig {
             reporter = reporter27;
             reporterMultiplier = reporterMultiplier27;
         } else if (i == 28) {
+            cToken = cToken28;
             underlying = underlying28;
             symbolHash = symbolHash28;
             baseUnit = baseUnit28;
@@ -1138,6 +1282,7 @@ contract UniswapConfig {
             reporter = reporter28;
             reporterMultiplier = reporterMultiplier28;
         } else if (i == 29) {
+            cToken = cToken29;
             underlying = underlying29;
             symbolHash = symbolHash29;
             baseUnit = baseUnit29;
@@ -1147,6 +1292,7 @@ contract UniswapConfig {
             reporter = reporter29;
             reporterMultiplier = reporterMultiplier29;
         } else if (i == 30) {
+            cToken = cToken30;
             underlying = underlying30;
             symbolHash = symbolHash30;
             baseUnit = baseUnit30;
@@ -1156,6 +1302,7 @@ contract UniswapConfig {
             reporter = reporter30;
             reporterMultiplier = reporterMultiplier30;
         } else if (i == 31) {
+            cToken = cToken31;
             underlying = underlying31;
             symbolHash = symbolHash31;
             baseUnit = baseUnit31;
@@ -1165,6 +1312,7 @@ contract UniswapConfig {
             reporter = reporter31;
             reporterMultiplier = reporterMultiplier31;
         } else if (i == 32) {
+            cToken = cToken32;
             underlying = underlying32;
             symbolHash = symbolHash32;
             baseUnit = baseUnit32;
@@ -1174,6 +1322,7 @@ contract UniswapConfig {
             reporter = reporter32;
             reporterMultiplier = reporterMultiplier32;
         } else if (i == 33) {
+            cToken = cToken33;
             underlying = underlying33;
             symbolHash = symbolHash33;
             baseUnit = baseUnit33;
@@ -1183,6 +1332,7 @@ contract UniswapConfig {
             reporter = reporter33;
             reporterMultiplier = reporterMultiplier33;
         } else if (i == 34) {
+            cToken = cToken34;
             underlying = underlying34;
             symbolHash = symbolHash34;
             baseUnit = baseUnit34;
@@ -1195,6 +1345,7 @@ contract UniswapConfig {
 
         return
             TokenConfig({
+                cToken: cToken,
                 underlying: underlying,
                 symbolHash: symbolHash,
                 baseUnit: baseUnit,
@@ -1244,6 +1395,25 @@ contract UniswapConfig {
         returns (TokenConfig memory)
     {
         return getTokenConfig(getSymbolHashIndex(symbolHash));
+    }
+
+    /**
+     * @notice Get the config for the cToken
+     * @dev If a config for the cToken is not found, falls back to searching for the underlying.
+     * @param cToken The address of the cToken of the config to get
+     * @return The config object
+     */
+    function getTokenConfigByCToken(address cToken)
+        public
+        view
+        returns (TokenConfig memory)
+    {
+        int256 index = getCTokenIndex(cToken);
+        if (index >= 0) {
+            return getTokenConfig(uint256(index));
+        }
+
+        return getTokenConfigByUnderlying(CErc20(cToken).underlying());
     }
 
     /**

--- a/contracts/Uniswap/UniswapConfig.sol
+++ b/contracts/Uniswap/UniswapConfig.sol
@@ -321,6 +321,10 @@ contract UniswapConfig {
     // Each bit i stores a bool, corresponding to the ith config.
     uint256 internal immutable isUniswapReversed;
 
+    /// @notice This error is thrown when the cToken address
+    /// is not set in the contract.
+    error CTokenAddressNotFound(address cToken);
+
     /**
      * @notice Construct an immutable store of configs into the contract data
      * @param configs The configs for the supported assets
@@ -792,7 +796,7 @@ contract UniswapConfig {
         return type(uint256).max;
     }
 
-    function getCTokenIndex(address cToken) internal view returns (int256) {
+    function getCTokenIndex(address cToken) internal view returns (uint256) {
         if (cToken == cToken00) return 0;
         if (cToken == cToken01) return 1;
         if (cToken == cToken02) return 2;
@@ -823,7 +827,7 @@ contract UniswapConfig {
         if (cToken == cToken27) return 27;
         if (cToken == cToken28) return 28;
 
-        return -1;
+        return type(uint256).max;
     }
 
     /**
@@ -1203,16 +1207,16 @@ contract UniswapConfig {
         view
         returns (TokenConfig memory)
     {
-        int256 index = getCTokenIndex(cToken);
-        if (index >= 0) {
+        uint256 index = getCTokenIndex(cToken);
+        if (index == type(uint256).max) {
             return getTokenConfig(uint256(index));
         }
-
-        return getTokenConfigByUnderlying(CErc20(cToken).underlying());
+        revert CTokenAddressNotFound(cToken);
     }
 
     /**
      * @notice Get the config for an underlying asset
+     * @dev The underlying address of ETH is the zero address
      * @param underlying The address of the underlying asset of the config to get
      * @return The config object
      */

--- a/contracts/Uniswap/UniswapConfig.sol
+++ b/contracts/Uniswap/UniswapConfig.sol
@@ -42,7 +42,7 @@ contract UniswapConfig {
 
     /// @notice The max number of tokens this contract is hardcoded to support
     /// @dev Do not change this variable without updating all the fields throughout the contract.
-    uint256 public constant MAX_TOKENS = 35;
+    uint256 public constant MAX_TOKENS = 29;
 
     /// @notice The number of tokens this contract actually supports
     uint256 public immutable numTokens;
@@ -76,12 +76,6 @@ contract UniswapConfig {
     address internal immutable cToken26;
     address internal immutable cToken27;
     address internal immutable cToken28;
-    address internal immutable cToken29;
-    address internal immutable cToken30;
-    address internal immutable cToken31;
-    address internal immutable cToken32;
-    address internal immutable cToken33;
-    address internal immutable cToken34;
 
     address internal immutable underlying00;
     address internal immutable underlying01;
@@ -112,12 +106,6 @@ contract UniswapConfig {
     address internal immutable underlying26;
     address internal immutable underlying27;
     address internal immutable underlying28;
-    address internal immutable underlying29;
-    address internal immutable underlying30;
-    address internal immutable underlying31;
-    address internal immutable underlying32;
-    address internal immutable underlying33;
-    address internal immutable underlying34;
 
     bytes32 internal immutable symbolHash00;
     bytes32 internal immutable symbolHash01;
@@ -148,12 +136,6 @@ contract UniswapConfig {
     bytes32 internal immutable symbolHash26;
     bytes32 internal immutable symbolHash27;
     bytes32 internal immutable symbolHash28;
-    bytes32 internal immutable symbolHash29;
-    bytes32 internal immutable symbolHash30;
-    bytes32 internal immutable symbolHash31;
-    bytes32 internal immutable symbolHash32;
-    bytes32 internal immutable symbolHash33;
-    bytes32 internal immutable symbolHash34;
 
     uint256 internal immutable baseUnit00;
     uint256 internal immutable baseUnit01;
@@ -184,12 +166,6 @@ contract UniswapConfig {
     uint256 internal immutable baseUnit26;
     uint256 internal immutable baseUnit27;
     uint256 internal immutable baseUnit28;
-    uint256 internal immutable baseUnit29;
-    uint256 internal immutable baseUnit30;
-    uint256 internal immutable baseUnit31;
-    uint256 internal immutable baseUnit32;
-    uint256 internal immutable baseUnit33;
-    uint256 internal immutable baseUnit34;
 
     PriceSource internal immutable priceSource00;
     PriceSource internal immutable priceSource01;
@@ -220,12 +196,6 @@ contract UniswapConfig {
     PriceSource internal immutable priceSource26;
     PriceSource internal immutable priceSource27;
     PriceSource internal immutable priceSource28;
-    PriceSource internal immutable priceSource29;
-    PriceSource internal immutable priceSource30;
-    PriceSource internal immutable priceSource31;
-    PriceSource internal immutable priceSource32;
-    PriceSource internal immutable priceSource33;
-    PriceSource internal immutable priceSource34;
 
     uint256 internal immutable fixedPrice00;
     uint256 internal immutable fixedPrice01;
@@ -256,12 +226,6 @@ contract UniswapConfig {
     uint256 internal immutable fixedPrice26;
     uint256 internal immutable fixedPrice27;
     uint256 internal immutable fixedPrice28;
-    uint256 internal immutable fixedPrice29;
-    uint256 internal immutable fixedPrice30;
-    uint256 internal immutable fixedPrice31;
-    uint256 internal immutable fixedPrice32;
-    uint256 internal immutable fixedPrice33;
-    uint256 internal immutable fixedPrice34;
 
     address internal immutable uniswapMarket00;
     address internal immutable uniswapMarket01;
@@ -292,12 +256,6 @@ contract UniswapConfig {
     address internal immutable uniswapMarket26;
     address internal immutable uniswapMarket27;
     address internal immutable uniswapMarket28;
-    address internal immutable uniswapMarket29;
-    address internal immutable uniswapMarket30;
-    address internal immutable uniswapMarket31;
-    address internal immutable uniswapMarket32;
-    address internal immutable uniswapMarket33;
-    address internal immutable uniswapMarket34;
 
     address internal immutable reporter00;
     address internal immutable reporter01;
@@ -328,12 +286,6 @@ contract UniswapConfig {
     address internal immutable reporter26;
     address internal immutable reporter27;
     address internal immutable reporter28;
-    address internal immutable reporter29;
-    address internal immutable reporter30;
-    address internal immutable reporter31;
-    address internal immutable reporter32;
-    address internal immutable reporter33;
-    address internal immutable reporter34;
 
     uint256 internal immutable reporterMultiplier00;
     uint256 internal immutable reporterMultiplier01;
@@ -364,12 +316,6 @@ contract UniswapConfig {
     uint256 internal immutable reporterMultiplier26;
     uint256 internal immutable reporterMultiplier27;
     uint256 internal immutable reporterMultiplier28;
-    uint256 internal immutable reporterMultiplier29;
-    uint256 internal immutable reporterMultiplier30;
-    uint256 internal immutable reporterMultiplier31;
-    uint256 internal immutable reporterMultiplier32;
-    uint256 internal immutable reporterMultiplier33;
-    uint256 internal immutable reporterMultiplier34;
 
     // Contract bytecode size optimization:
     // Each bit i stores a bool, corresponding to the ith config.
@@ -702,72 +648,6 @@ contract UniswapConfig {
         reporter28 = config.reporter;
         reporterMultiplier28 = config.reporterMultiplier;
 
-        config = get(configs, 29);
-        cToken29 = config.cToken;
-        underlying29 = config.underlying;
-        symbolHash29 = config.symbolHash;
-        baseUnit29 = config.baseUnit;
-        priceSource29 = config.priceSource;
-        fixedPrice29 = config.fixedPrice;
-        uniswapMarket29 = config.uniswapMarket;
-        reporter29 = config.reporter;
-        reporterMultiplier29 = config.reporterMultiplier;
-
-        config = get(configs, 30);
-        cToken30 = config.cToken;
-        underlying30 = config.underlying;
-        symbolHash30 = config.symbolHash;
-        baseUnit30 = config.baseUnit;
-        priceSource30 = config.priceSource;
-        fixedPrice30 = config.fixedPrice;
-        uniswapMarket30 = config.uniswapMarket;
-        reporter30 = config.reporter;
-        reporterMultiplier30 = config.reporterMultiplier;
-
-        config = get(configs, 31);
-        cToken31 = config.cToken;
-        underlying31 = config.underlying;
-        symbolHash31 = config.symbolHash;
-        baseUnit31 = config.baseUnit;
-        priceSource31 = config.priceSource;
-        fixedPrice31 = config.fixedPrice;
-        uniswapMarket31 = config.uniswapMarket;
-        reporter31 = config.reporter;
-        reporterMultiplier31 = config.reporterMultiplier;
-
-        config = get(configs, 32);
-        cToken32 = config.cToken;
-        underlying32 = config.underlying;
-        symbolHash32 = config.symbolHash;
-        baseUnit32 = config.baseUnit;
-        priceSource32 = config.priceSource;
-        fixedPrice32 = config.fixedPrice;
-        uniswapMarket32 = config.uniswapMarket;
-        reporter32 = config.reporter;
-        reporterMultiplier32 = config.reporterMultiplier;
-
-        config = get(configs, 33);
-        cToken33 = config.cToken;
-        underlying33 = config.underlying;
-        symbolHash33 = config.symbolHash;
-        baseUnit33 = config.baseUnit;
-        priceSource33 = config.priceSource;
-        fixedPrice33 = config.fixedPrice;
-        uniswapMarket33 = config.uniswapMarket;
-        reporter33 = config.reporter;
-        reporterMultiplier33 = config.reporterMultiplier;
-
-        config = get(configs, 34);
-        cToken34 = config.cToken;
-        underlying34 = config.underlying;
-        symbolHash34 = config.symbolHash;
-        baseUnit34 = config.baseUnit;
-        priceSource34 = config.priceSource;
-        fixedPrice34 = config.fixedPrice;
-        uniswapMarket34 = config.uniswapMarket;
-        reporter34 = config.reporter;
-        reporterMultiplier34 = config.reporterMultiplier;
-
         uint256 isUniswapReversed_;
         uint256 numTokenConfigs = configs.length;
         for (uint256 i = 0; i < numTokenConfigs; i++) {
@@ -832,12 +712,6 @@ contract UniswapConfig {
         if (reporter == reporter26) return 26;
         if (reporter == reporter27) return 27;
         if (reporter == reporter28) return 28;
-        if (reporter == reporter29) return 29;
-        if (reporter == reporter30) return 30;
-        if (reporter == reporter31) return 31;
-        if (reporter == reporter32) return 32;
-        if (reporter == reporter33) return 33;
-        if (reporter == reporter34) return 34;
 
         return MAX_INTEGER;
     }
@@ -876,12 +750,6 @@ contract UniswapConfig {
         if (underlying == underlying26) return 26;
         if (underlying == underlying27) return 27;
         if (underlying == underlying28) return 28;
-        if (underlying == underlying29) return 29;
-        if (underlying == underlying30) return 30;
-        if (underlying == underlying31) return 31;
-        if (underlying == underlying32) return 32;
-        if (underlying == underlying33) return 33;
-        if (underlying == underlying34) return 34;
 
         return type(uint256).max;
     }
@@ -920,12 +788,6 @@ contract UniswapConfig {
         if (symbolHash == symbolHash26) return 26;
         if (symbolHash == symbolHash27) return 27;
         if (symbolHash == symbolHash28) return 28;
-        if (symbolHash == symbolHash29) return 29;
-        if (symbolHash == symbolHash30) return 30;
-        if (symbolHash == symbolHash31) return 31;
-        if (symbolHash == symbolHash32) return 32;
-        if (symbolHash == symbolHash33) return 33;
-        if (symbolHash == symbolHash34) return 34;
 
         return type(uint256).max;
     }
@@ -960,12 +822,6 @@ contract UniswapConfig {
         if (cToken == cToken26) return 26;
         if (cToken == cToken27) return 27;
         if (cToken == cToken28) return 28;
-        if (cToken == cToken29) return 29;
-        if (cToken == cToken30) return 30;
-        if (cToken == cToken31) return 31;
-        if (cToken == cToken32) return 32;
-        if (cToken == cToken33) return 33;
-        if (cToken == cToken34) return 34;
 
         return -1;
     }
@@ -1281,68 +1137,7 @@ contract UniswapConfig {
             uniswapMarket = uniswapMarket28;
             reporter = reporter28;
             reporterMultiplier = reporterMultiplier28;
-        } else if (i == 29) {
-            cToken = cToken29;
-            underlying = underlying29;
-            symbolHash = symbolHash29;
-            baseUnit = baseUnit29;
-            priceSource = priceSource29;
-            fixedPrice = fixedPrice29;
-            uniswapMarket = uniswapMarket29;
-            reporter = reporter29;
-            reporterMultiplier = reporterMultiplier29;
-        } else if (i == 30) {
-            cToken = cToken30;
-            underlying = underlying30;
-            symbolHash = symbolHash30;
-            baseUnit = baseUnit30;
-            priceSource = priceSource30;
-            fixedPrice = fixedPrice30;
-            uniswapMarket = uniswapMarket30;
-            reporter = reporter30;
-            reporterMultiplier = reporterMultiplier30;
-        } else if (i == 31) {
-            cToken = cToken31;
-            underlying = underlying31;
-            symbolHash = symbolHash31;
-            baseUnit = baseUnit31;
-            priceSource = priceSource31;
-            fixedPrice = fixedPrice31;
-            uniswapMarket = uniswapMarket31;
-            reporter = reporter31;
-            reporterMultiplier = reporterMultiplier31;
-        } else if (i == 32) {
-            cToken = cToken32;
-            underlying = underlying32;
-            symbolHash = symbolHash32;
-            baseUnit = baseUnit32;
-            priceSource = priceSource32;
-            fixedPrice = fixedPrice32;
-            uniswapMarket = uniswapMarket32;
-            reporter = reporter32;
-            reporterMultiplier = reporterMultiplier32;
-        } else if (i == 33) {
-            cToken = cToken33;
-            underlying = underlying33;
-            symbolHash = symbolHash33;
-            baseUnit = baseUnit33;
-            priceSource = priceSource33;
-            fixedPrice = fixedPrice33;
-            uniswapMarket = uniswapMarket33;
-            reporter = reporter33;
-            reporterMultiplier = reporterMultiplier33;
-        } else if (i == 34) {
-            cToken = cToken34;
-            underlying = underlying34;
-            symbolHash = symbolHash34;
-            baseUnit = baseUnit34;
-            priceSource = priceSource34;
-            fixedPrice = fixedPrice34;
-            uniswapMarket = uniswapMarket34;
-            reporter = reporter34;
-            reporterMultiplier = reporterMultiplier34;
         }
-
         return
             TokenConfig({
                 cToken: cToken,

--- a/contracts/Uniswap/UniswapConfig.sol
+++ b/contracts/Uniswap/UniswapConfig.sol
@@ -751,7 +751,7 @@ contract UniswapConfig {
         if (underlying == underlying27) return 27;
         if (underlying == underlying28) return 28;
 
-        return type(uint256).max;
+        return MAX_INTEGER;
     }
 
     function getSymbolHashIndex(bytes32 symbolHash)
@@ -789,7 +789,7 @@ contract UniswapConfig {
         if (symbolHash == symbolHash27) return 27;
         if (symbolHash == symbolHash28) return 28;
 
-        return type(uint256).max;
+        return MAX_INTEGER;
     }
 
     function getCTokenIndex(address cToken) internal view returns (uint256) {

--- a/contracts/Uniswap/UniswapConfig.sol
+++ b/contracts/Uniswap/UniswapConfig.sol
@@ -321,10 +321,6 @@ contract UniswapConfig {
     // Each bit i stores a bool, corresponding to the ith config.
     uint256 internal immutable isUniswapReversed;
 
-    /// @notice This error is thrown when the cToken address
-    /// is not set in the contract.
-    error CTokenAddressNotFound(address cToken);
-
     /**
      * @notice Construct an immutable store of configs into the contract data
      * @param configs The configs for the supported assets
@@ -1208,10 +1204,7 @@ contract UniswapConfig {
         returns (TokenConfig memory)
     {
         uint256 index = getCTokenIndex(cToken);
-        if (index == type(uint256).max) {
-            return getTokenConfig(uint256(index));
-        }
-        revert CTokenAddressNotFound(cToken);
+        return getTokenConfig(index);
     }
 
     /**

--- a/contracts/Uniswap/UniswapConfig.sol
+++ b/contracts/Uniswap/UniswapConfig.sol
@@ -823,7 +823,7 @@ contract UniswapConfig {
         if (cToken == cToken27) return 27;
         if (cToken == cToken28) return 28;
 
-        return type(uint256).max;
+        return MAX_INTEGER;
     }
 
     /**

--- a/test/UniswapAnchoredView.test.ts
+++ b/test/UniswapAnchoredView.test.ts
@@ -477,7 +477,7 @@ describe("UniswapAnchoredView", () => {
     });
   });
 
-  describe.only("getUnderlyingPrice", () => {
+  describe("getUnderlyingPrice", () => {
     // everything must return 1e36 - underlying units
 
     beforeEach(async () => {

--- a/test/UniswapAnchoredView.test.ts
+++ b/test/UniswapAnchoredView.test.ts
@@ -462,13 +462,11 @@ describe("UniswapAnchoredView", () => {
       ).deploy();
       await reporter.setUniswapAnchoredView(uniswapAnchoredView.address);
 
-      await expect(reporter.validate(95)).to.be.revertedWith(
-        "Not found"
-      );
+      await expect(reporter.validate(95)).to.be.revertedWith("Not found");
     });
   });
 
-  describe("getUnderlyingPrice", () => {
+  describe.only("getUnderlyingPrice", () => {
     // everything must return 1e36 - underlying units
 
     beforeEach(async () => {
@@ -794,10 +792,9 @@ describe("UniswapAnchoredView", () => {
 
     it("reverts if trying to activate failover for a non reporter price", async () => {
       await expect(
-        uniswapAnchoredView
-          .activateFailover(keccak256("SAI"))
+        uniswapAnchoredView.activateFailover(keccak256("SAI"))
       ).to.be.revertedWith("Not reporter");
-    })
+    });
 
     it("basic scenario, sets failoverActive and emits FailoverUpdated event with correct args", async () => {
       const bytes32EthSymbolHash = ethers.utils.hexZeroPad(

--- a/test/UniswapAnchoredView.test.ts
+++ b/test/UniswapAnchoredView.test.ts
@@ -35,6 +35,7 @@ interface CTokenConfig {
 
 // struct TokenConfig from UniswapConfig.sol; not exported by Typechain
 interface TokenConfig {
+  cToken: string;
   underlying: string;
   symbolHash: string; // bytes32
   baseUnit: BigNumberish;
@@ -93,10 +94,14 @@ async function setup({ isMockedView }: SetupOptions) {
           },
         ]);
         const fakeErc20 = await smock.fake([]);
-        fakeCToken.underlying.returns(() => {
-          // return another mock token as the underlying
-          return fakeErc20.address;
-        });
+        if (symbol !== "ETH") {
+          // ETH cToken does not have an "underlying" function.
+          fakeCToken.underlying.returns(() => {
+            // return another mock token as the underlying
+            return fakeErc20.address;
+          });
+        }
+
         return {
           symbol,
           addr: fakeCToken.address,
@@ -119,6 +124,7 @@ async function setup({ isMockedView }: SetupOptions) {
   const dummyAddress = address(0);
   const tokenConfigs: TokenConfig[] = [
     {
+      cToken: cToken.ETH.addr,
       underlying: cToken.ETH.underlying,
       symbolHash: keccak256("ETH"),
       baseUnit: uint(1e18),
@@ -130,6 +136,7 @@ async function setup({ isMockedView }: SetupOptions) {
       isUniswapReversed: true,
     },
     {
+      cToken: cToken.DAI.addr,
       underlying: cToken.DAI.underlying,
       symbolHash: keccak256("DAI"),
       baseUnit: uint(1e18),
@@ -141,6 +148,7 @@ async function setup({ isMockedView }: SetupOptions) {
       isUniswapReversed: false,
     },
     {
+      cToken: cToken.REP.addr,
       underlying: cToken.REP.underlying,
       symbolHash: keccak256("REPv2"),
       baseUnit: uint(1e18),
@@ -152,6 +160,7 @@ async function setup({ isMockedView }: SetupOptions) {
       isUniswapReversed: false,
     },
     {
+      cToken: cToken.USDT.addr,
       underlying: cToken.USDT.underlying,
       symbolHash: keccak256("USDT"),
       baseUnit: uint(1e6),
@@ -163,6 +172,7 @@ async function setup({ isMockedView }: SetupOptions) {
       isUniswapReversed: false,
     },
     {
+      cToken: cToken.SAI.addr,
       underlying: cToken.SAI.underlying,
       symbolHash: keccak256("SAI"),
       baseUnit: uint(1e18),
@@ -174,6 +184,7 @@ async function setup({ isMockedView }: SetupOptions) {
       isUniswapReversed: false,
     },
     {
+      cToken: cToken.WBTC.addr,
       underlying: cToken.WBTC.underlying,
       symbolHash: keccak256("BTC"),
       baseUnit: uint(1e8),
@@ -619,6 +630,7 @@ describe("UniswapAnchoredView", () => {
       const tokenConfigs: TokenConfig[] = [
         // Set dummy address as a uniswap market address
         {
+          cToken: cToken.ETH.addr,
           underlying: dummyAddress,
           symbolHash: keccak256("ETH"),
           baseUnit: uint(1e18),
@@ -630,6 +642,7 @@ describe("UniswapAnchoredView", () => {
           isUniswapReversed: true,
         },
         {
+          cToken: cToken.DAI.addr,
           underlying: dummyAddress,
           symbolHash: keccak256("DAI"),
           baseUnit: uint(1e18),
@@ -641,6 +654,7 @@ describe("UniswapAnchoredView", () => {
           isUniswapReversed: false,
         },
         {
+          cToken: cToken.REP.addr,
           underlying: dummyAddress,
           symbolHash: keccak256("REP"),
           baseUnit: uint(1e18),
@@ -667,6 +681,7 @@ describe("UniswapAnchoredView", () => {
       const dummyAddress = address(0);
       const tokenConfigs1: TokenConfig[] = [
         {
+          cToken: cToken.USDT.addr,
           underlying: dummyAddress,
           symbolHash: keccak256("USDT"),
           baseUnit: uint(1e18),
@@ -688,6 +703,7 @@ describe("UniswapAnchoredView", () => {
 
       const tokenConfigs2: TokenConfig[] = [
         {
+          cToken: cToken.USDT.addr,
           underlying: dummyAddress,
           symbolHash: keccak256("USDT"),
           baseUnit: uint(1e18),
@@ -714,6 +730,7 @@ describe("UniswapAnchoredView", () => {
       const dummyAddress = address(0);
       const tokenConfigs1: TokenConfig[] = [
         {
+          cToken: cToken.USDT.addr,
           underlying: dummyAddress,
           symbolHash: keccak256("USDT"),
           baseUnit: uint(1e18),
@@ -735,6 +752,7 @@ describe("UniswapAnchoredView", () => {
 
       const tokenConfigs2: TokenConfig[] = [
         {
+          cToken: cToken.USDT.addr,
           underlying: dummyAddress,
           symbolHash: keccak256("USDT"),
           baseUnit: uint(1e18),

--- a/test/UniswapConfig.test.ts
+++ b/test/UniswapConfig.test.ts
@@ -169,8 +169,8 @@ describe("UniswapConfig", () => {
       .map((_, i) => {
         const symbol = String.fromCharCode("a".charCodeAt(0) + i);
         return {
-          cToken: address(i + 1),
-          underlying: address(i + 2),
+          cToken: address(i),
+          underlying: address(i + 1),
           symbolHash: keccak256(symbol),
           baseUnit: uint(i + 49),
           priceSource: 0,
@@ -188,14 +188,14 @@ describe("UniswapConfig", () => {
     const tx9_ = await deployer.sendTransaction(tx9__);
     const tx9 = await tx9_.wait();
     expect(cfg9.underlying).to.equal(address(10));
-    expect(tx9.gasUsed).to.equal(22830);
+    expect(tx9.gasUsed).to.equal(22970);
 
     const cfg25 = await contract.getTokenConfig(24);
     const tx25__ = await contract.populateTransaction.getTokenConfig(24);
     const tx25_ = await deployer.sendTransaction(tx25__);
     const tx25 = await tx25_.wait();
     expect(cfg25.underlying).to.equal(address(25));
-    expect(tx25.gasUsed).to.equal(23220);
+    expect(tx25.gasUsed).to.equal(23360);
 
     const cfgY = await contract.getTokenConfigBySymbol("y");
     const txY__ = await contract.populateTransaction.getTokenConfigBySymbol(
@@ -204,7 +204,7 @@ describe("UniswapConfig", () => {
     const txY_ = await deployer.sendTransaction(txY__);
     const txY = await txY_.wait();
     expect(cfgY.underlying).to.equal(address(25));
-    expect(txY.gasUsed).to.equal(25070);
+    expect(txY.gasUsed).to.equal(25252);
 
     const cfgCT26 = await contract.getTokenConfigByUnderlying(address(25));
     const txCT26__ =
@@ -214,7 +214,7 @@ describe("UniswapConfig", () => {
     const txCT26_ = await deployer.sendTransaction(txCT26__);
     const txCT26 = await txCT26_.wait();
     expect(cfgCT26.underlying).to.equal(address(25));
-    expect(txCT26.gasUsed).to.equal(25188);
+    expect(txCT26.gasUsed).to.equal(25348);
 
     const cfgR26 = await contract.getTokenConfigByReporter(address(24 + 51));
     const txR26__ = await contract.populateTransaction.getTokenConfigByReporter(
@@ -223,7 +223,7 @@ describe("UniswapConfig", () => {
     const txR26_ = await deployer.sendTransaction(txR26__);
     const txR26 = await txR26_.wait();
     expect(cfgR26.underlying).to.equal(address(25));
-    expect(txR26.gasUsed).to.equal(25166);
+    expect(txR26.gasUsed).to.equal(25326);
 
     const cfgU26 = await contract.getTokenConfigByUnderlying(address(25));
     const txU26__ =
@@ -233,6 +233,6 @@ describe("UniswapConfig", () => {
     const txU26_ = await deployer.sendTransaction(txU26__);
     const txU26 = await txU26_.wait();
     expect(cfgU26.underlying).to.equal(address(25));
-    expect(txU26.gasUsed).to.equal(25188);
+    expect(txU26.gasUsed).to.equal(25348);
   });
 });

--- a/test/UniswapConfig.test.ts
+++ b/test/UniswapConfig.test.ts
@@ -8,7 +8,7 @@ import { smock } from "@defi-wonderland/smock";
 use(smock.matchers);
 
 // Update this to the max number of tokens supported in UniswapConfig.sol
-const MAX_TOKENS = 35;
+const MAX_TOKENS = 29;
 
 describe("UniswapConfig", () => {
   let signers: SignerWithAddress[];

--- a/test/UniswapConfig.test.ts
+++ b/test/UniswapConfig.test.ts
@@ -34,6 +34,7 @@ describe("UniswapConfig", () => {
 
     const contract = await new UniswapConfig__factory(deployer).deploy([
       {
+        cToken: address(10),
         underlying: address(0),
         symbolHash: keccak256("ETH"),
         baseUnit: uint(1e18),
@@ -45,6 +46,7 @@ describe("UniswapConfig", () => {
         isUniswapReversed: false,
       },
       {
+        cToken: address(11),
         underlying: address(3),
         symbolHash: keccak256("BTC"),
         baseUnit: uint(1e18),
@@ -56,6 +58,7 @@ describe("UniswapConfig", () => {
         isUniswapReversed: true,
       },
       {
+        cToken: address(12),
         underlying: address(4),
         symbolHash: keccak256("REP"),
         baseUnit: uint(1e18),
@@ -87,9 +90,7 @@ describe("UniswapConfig", () => {
     expect(cfg0).not.to.deep.equal(cfg1);
     expect(cfgU2).to.deep.equal(cfg2);
 
-    await expect(contract.getTokenConfig(3)).to.be.revertedWith(
-      "Not found"
-    );
+    await expect(contract.getTokenConfig(3)).to.be.revertedWith("Not found");
     await expect(contract.getTokenConfigBySymbol("COMP")).to.be.revertedWith(
       "Not found"
     );
@@ -110,6 +111,7 @@ describe("UniswapConfig", () => {
       .map((_, i) => String.fromCharCode("a".charCodeAt(0) + i));
     const configs = symbols.map((symbol, i) => {
       return {
+        cToken: address(i),
         underlying: address(i),
         symbolHash: keccak256(symbol),
         baseUnit: uint(i + 49),
@@ -167,7 +169,8 @@ describe("UniswapConfig", () => {
       .map((_, i) => {
         const symbol = String.fromCharCode("a".charCodeAt(0) + i);
         return {
-          underlying: address(i + 1),
+          cToken: address(i + 1),
+          underlying: address(i + 2),
           symbolHash: keccak256(symbol),
           baseUnit: uint(i + 49),
           priceSource: 0,


### PR DESCRIPTION
**Summary**

This change updates the `getUnderlyingPrice` function to fetch the token configuration using the `cToken` address instead of calling the `underlying` function from the cToken.

**Bug**

`getUnderlyingPrice` fails when passing in the address of the `cETH` token as `cETH` does not implement the `underlying` function like other cTokens.