### PR TITLE
Add Price Oracle contract that reads CLL feeds directly

### DIFF
--- a/configuration/parameters-price-oracle.ts
+++ b/configuration/parameters-price-oracle.ts
@@ -1,0 +1,115 @@
+export type TokenConfig = {
+  // The address of the Compound Token
+  cToken: string;
+  // The number of smallest units of measurement in a single whole unit.
+  baseUnit: string;
+  // Address to Chainlink feed used for asset price
+  priceFeed: string;
+};
+
+const parameters: TokenConfig[] = [
+  {
+    // "NAME": "ETH",
+    cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+  },
+  {
+    // "NAME": "DAI",
+    cToken: "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0xaed0c38402a5d19df6e4c03f4e2dced6e29c1ee9",
+  },
+  {
+    // "NAME": "USDC",
+    cToken: "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
+    baseUnit: "1000000",
+    priceFeed: "0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
+  },
+  {
+    // "NAME": "USDT",
+    cToken: "0xf650C3d88D12dB855b8bf7D11Be6C55A4e07dCC9",
+    baseUnit: "1000000",
+    priceFeed: "0x3e7d1eab13ad0104d2750b8863b489d65364e32d",
+  },
+  {
+    // "NAME": "WBTCv2",
+    cToken: "0xccf4429db6322d5c611ee964527d42e5d685dd6a",
+    baseUnit: "100000000",
+    priceFeed: "0x45939657d1CA34A8FA39A924B71D28Fe8431e581", // Custom Compound Feed
+  },
+  {
+    // "NAME": "BAT",
+    cToken: "0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0x9441D7556e7820B5ca42082cfa99487D56AcA958",
+  },
+  {
+    // "NAME": "ZRX",
+    cToken: "0xB3319f5D18Bc0D84dD1b4825Dcde5d5f7266d407",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0x2885d15b8af22648b98b122b22fdf4d2a56c6023",
+  },
+  {
+    // "NAME": "UNI",
+    cToken: "0x35A18000230DA775CAc24873d00Ff85BccdeD550",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0x553303d460ee0afb37edff9be42922d8ff63220e",
+  },
+  {
+    // "NAME": "COMP",
+    cToken: "0x70e36f6BF80a52b3B46b3aF8e106CC0ed743E8e4",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0xdbd020caef83efd542f4de03e3cf0c28a4428bd5",
+  },
+  {
+    // "NAME": "LINK",
+    cToken: "0xFAce851a4921ce59e912d19329929CE6da6EB0c7",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0x2c1d072e956affc0d435cb7ac38ef18d24d9127c",
+  },
+  {
+    // "NAME": "TUSD",
+    cToken: "0x12392F67bdf24faE0AF363c24aC620a2f67DAd86",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0xec746ecf986e2927abd291a2a1716c940100f8ba",
+  },
+  {
+    // "NAME": "AAVE",
+    cToken: "0xe65cdB6479BaC1e22340E4E755fAE7E509EcD06c",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0x547a514d5e3769680ce22b2361c10ea13619e8a9",
+  },
+  {
+    // "NAME": "SUSHI",
+    cToken: "0x4B0181102A0112A2ef11AbEE5563bb4a3176c9d7",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0xcc70f09a6cc17553b2e31954cd36e4a2d89501f7",
+  },
+  {
+    // "NAME": "MKR",
+    cToken: "0x95b4eF2869eBD94BEb4eEE400a99824BF5DC325b",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0xec1d1b3b0443256cc3860e24a46f108e699484aa",
+  },
+  {
+    // "NAME": "YFI",
+    cToken: "0x80a2AE356fc9ef4305676f7a3E2Ed04e12C33946",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0xa027702dbb89fbd58938e4324ac03b58d812b0e1",
+  },
+  {
+    // "NAME": "USDP",
+    cToken: "0x041171993284df560249B57358F931D9eB7b925D",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0x09023c0da49aaf8fc3fa3adf34c6a7016d38d5e3",
+  },
+  {
+    // "NAME": "MATIC",
+    cToken: "0x944dd1c7ce133b75880cee913d513f8c07312393",
+    baseUnit: "1000000000000000000",
+    priceFeed: "0x7bac85a8a13a4bcd8abb3eb7d6b4d632c5a57676",
+  },
+];
+
+export default parameters;

--- a/contracts/PriceOracle/PriceOracle.sol
+++ b/contracts/PriceOracle/PriceOracle.sol
@@ -10,10 +10,10 @@ contract PriceOracle is Ownable {
     /// @dev Configuration used to return the USD price for the associated cToken asset and base unit needed for formatting
     /// There should be 1 TokenConfig object for each supported asset, passed in the constructor.
     struct TokenConfig {
-        // The address of the Compound Token
-        address cToken;
-        // The number of smallest units of measurement in a single whole unit. (e.g. 1e18 for ETH)
+        // Number of smallest units of measurement in a single whole unit. (e.g. 1e18 for ETH)
         uint256 baseUnit;
+        // Address of the Compound Token
+        address cToken;
         // Address of the feed used to retrieve the asset's price
         address priceFeed;
     }
@@ -22,13 +22,60 @@ contract PriceOracle is Ownable {
     mapping (address => TokenConfig) tokenConfigs;
 
     /// @notice The event emitted when a new asset is added to the mapping
+    /// @param cToken cToken address that the config was added for
+    /// @param baseUnit Number of smallest units of measurement in a single whole unit for the underlying cToken asset.
+    /// @param priceFeed Address of the feed used to retrieve the asset's price
     event PriceOracleAssetAdded(address indexed cToken, uint256 baseUnit, address priceFeed);
 
     /// @notice The event emitted when the price feed for an existing config is updated
+    /// @param cToken cToken address that the config was added for
+    /// @param oldPriceFeed The existing price feed address configured in the token config
+    /// @param newPriceFeed The new price feed address the token config is being updated to
     event PriceOracleAssetPriceFeedUpdated(address indexed cToken, address oldPriceFeed, address newPriceFeed);
 
     /// @notice The event emitted when an asset is removed to the mapping
+    /// @param cToken cToken address that the config was removed for
+    /// @param baseUnit Number of smallest units of measurement in a single whole unit set in the removed config.
+    /// @param priceFeed Address price feed set in the removed config
     event PriceOracleAssetRemoved(address indexed cToken, uint256 baseUnit, address priceFeed);
+
+    /// @notice The max decimals value allowed for price feed
+    uint8 internal constant MAX_DECIMALS = 72;
+
+    /// @notice The number of digits the price is scaled to before adjusted by the base units
+    uint8 internal constant PRICE_SCALE = 36;
+
+    /// @notice cToken address for config not provided
+    error MissingCTokenAddress();
+
+    /// @notice BaseUnit is missing or set to value 0
+    error InvalidBaseUnit();
+
+    /// @notice Price feed missing or duplicated
+    /// @param priceFeed Price feed address provided
+    error InvalidPriceFeed(address priceFeed);
+
+    /// @notice Config already exists
+    /// @param cToken cToken address provided
+    error DuplicateConfig(address cToken);
+
+    /// @notice Config does not exist in the mapping
+    /// @param cToken cToken address provided
+    error ConfigNotFound(address cToken);
+
+    /// @notice Decimals retrieved from the price feed is too large to use for formatting
+    /// @param decimals Decimals retrieve from the price feed
+    error DecimalsTooLarge(uint8 decimals);
+
+    /// @notice Price returned by the feed is negative
+    /// @param price Price returned from the price feed
+    error NegativePrice(int256 price);
+
+    /// @notice Same price feed as the existing one was provided when updating the price feed config
+    /// @param cToken cToken address that the price feed update is for
+    /// @param existingPriceFeed Price feed address set in the existing config
+    /// @param newPriceFeed Price feed address provided to update to
+    error UnchangedPriceFeed(address cToken, address existingPriceFeed, address newPriceFeed);
 
     /**
      * @notice Construct a Price Oracle contract for a set of token configurations
@@ -40,14 +87,18 @@ contract PriceOracle is Ownable {
             TokenConfig memory config = configs[i];
             validateTokenConfig(config);
             // Check if duplicate configs were submitted for the same cToken
-            require(tokenConfigs[config.cToken].cToken == address(0), "Duplicate config for cToken found");
+            if (tokenConfigs[config.cToken].cToken != address(0)) revert DuplicateConfig(config.cToken);
             tokenConfigs[config.cToken] = config;
         }
     }
 
     /**
      * @notice Get the underlying price of a cToken, in the format expected by the Comptroller.
-     * @dev Implements the PriceOracle interface for Compound v2.
+     * @dev Comptroller needs prices in the format: ${raw price} * 1e(36-decimals) / baseUnit
+     *      'baseUnit' is the number of smallest units of measurement in a single whole unit.
+     *      'decimals' is a value supplied by the price feed that represent the number of decimals the price feed reports with.
+     *      For example, the baseUnit of ETH is 1e18 and its price feed provides 8 decimal places
+     *      We must scale the price such as: ${raw price} * 1e(36 - 8) / 1e18.
      * @param cToken The cToken address for price retrieval
      * @return Price denominated in USD for the given cToken address, in the format expected by the Comptroller.
      */
@@ -57,14 +108,14 @@ contract PriceOracle is Ownable {
         returns (uint256)
     {
         TokenConfig memory config = tokenConfigs[cToken];
-        require(config.cToken != address(0), "Config not found for cToken");
+        if (config.cToken == address(0)) revert ConfigNotFound(cToken);
         // Initialize the aggregator to read the price from
         AggregatorV3Interface priceFeed = AggregatorV3Interface(config.priceFeed);
         // Retrieve decimals from feed for formatting
         uint8 decimals = priceFeed.decimals();
         // Fail safe check since this is an unrealistic scenario. The number of digits that the int256 answer can have naturally limits decimals
         // but this protects against an erroneous uint8 values
-        require(decimals <= 72, "Decimals is too large to properly use in formatting the price");
+        if (decimals > MAX_DECIMALS) revert DecimalsTooLarge(decimals);
         // Retrieve price from feed
         (
             /* uint80 roundID */,
@@ -73,24 +124,18 @@ contract PriceOracle is Ownable {
             /*uint timeStamp*/,
             /*uint80 answeredInRound*/
         ) = priceFeed.latestRoundData();
-        require(answer >= 0, "Price cannot be negative");
+        if (answer < 0) revert NegativePrice(answer);
         uint256 price = uint256(answer);
-
-        // Comptroller needs prices in the format: ${raw price} * 1e36 / baseUnit
-        // The baseUnit of an asset is the amount of the smallest denomination of that asset per whole.
-        // The decimals represent the number of decimals the price feed answer reports with. Supplied by the price feed.
-        // For example, the baseUnit of ETH is 1e18 and its price feed provides 8 decimal places
-        // We must scale the price by 1e(36 - decimals) / baseUnit
 
         // Number of decimals determines whether the price needs to be multiplied or divided for scaling
         // Handle the 2 scenarios separately to ensure a non-fractional scale value
-        if (decimals <= 36) {
+        if (decimals <= PRICE_SCALE) {
             // Decimals is always >=0 so the scale max value is 1e36 here and not at risk of overflowing
-            uint256 scale = 10 ** (36 - decimals);
+            uint256 scale = 10 ** (PRICE_SCALE - decimals);
             return FullMath.mulDiv(price, scale, config.baseUnit);
         } else {
             // Decimals is capped at 72 by earlier validation so scale max value is 1e36 here and not at risk of overflowing
-            uint256 scale = 10 ** (decimals - 36);
+            uint256 scale = 10 ** (decimals - PRICE_SCALE);
             // Divide price by scale and base unit separately
             // Multiplying scale and base unit before dividing price could result in an overflow
             uint256 scaledPrice = FullMath.mulDiv(price, 1, scale);
@@ -105,7 +150,7 @@ contract PriceOracle is Ownable {
     function getConfig(address cToken) external view returns (TokenConfig memory) {
         TokenConfig memory config = tokenConfigs[cToken];
         // Check if config exists for cToken
-        require(config.cToken != address(0), "Config for cToken does not exist");
+        if (config.cToken == address(0)) revert ConfigNotFound(cToken);
         return config;
     }
 
@@ -114,9 +159,10 @@ contract PriceOracle is Ownable {
      * @param config Token config struct that contains the info for a new asset configuration
      */
     function addConfig(TokenConfig calldata config) external onlyOwner {
-        // Check if duplicate configs were submitted for the same cToken
-        require(tokenConfigs[config.cToken].cToken == address(0), "Config for cToken already exists");
         validateTokenConfig(config);
+        TokenConfig memory existingConfig = tokenConfigs[config.cToken];
+        // Check if duplicate configs were submitted for the same cToken
+        if (existingConfig.cToken != address(0)) revert DuplicateConfig(existingConfig.cToken);
 
         tokenConfigs[config.cToken] = config;
         emit PriceOracleAssetAdded(config.cToken, config.baseUnit, config.priceFeed);
@@ -130,13 +176,15 @@ contract PriceOracle is Ownable {
     function updateConfigPriceFeed(address cToken, address priceFeed) external onlyOwner {
         TokenConfig storage config = tokenConfigs[cToken];
         // Check if config exists for cToken
-        require(config.cToken != address(0), "Config does not exist for cToken");
+        if (config.cToken == address(0)) revert ConfigNotFound(cToken);
         // Validate price feed
-        require(priceFeed != address(0), "Invalid new price feed address");
-        require(config.priceFeed != priceFeed, "Price feed address same as the existing one");
+        if (priceFeed == address(0)) revert InvalidPriceFeed(priceFeed);
+        // Check if existing price feed is the same as the new one sent
+        if (config.priceFeed == priceFeed) revert UnchangedPriceFeed(cToken, config.priceFeed, priceFeed);
 
-        emit PriceOracleAssetPriceFeedUpdated(cToken, config.priceFeed, priceFeed);
+        address existingPriceFeed = config.priceFeed;
         config.priceFeed = priceFeed;
+        emit PriceOracleAssetPriceFeedUpdated(cToken, existingPriceFeed, priceFeed);
     }
 
     /**
@@ -146,7 +194,7 @@ contract PriceOracle is Ownable {
     function removeConfig(address cToken) external onlyOwner {
         TokenConfig memory config = tokenConfigs[cToken];
         // Check if config exists for cToken
-        require(config.cToken != address(0), "Config for cToken does not exist");
+        if (config.cToken == address(0)) revert ConfigNotFound(cToken);
 
         delete tokenConfigs[cToken];
         emit PriceOracleAssetRemoved(cToken, config.baseUnit, config.priceFeed);
@@ -158,9 +206,9 @@ contract PriceOracle is Ownable {
      * @param config TokenConfig struct that needs to be validated
      */
     function validateTokenConfig(TokenConfig memory config) internal pure {
-        require(config.cToken != address(0), "Config missing cToken address");
+        if (config.cToken == address(0)) revert MissingCTokenAddress();
         // Dual check of field being present and being non-zero
-        require(config.baseUnit != 0, "Config either missing base unit or set to 0");
-        require(config.priceFeed != address(0), "Config missing price feed address");
+        if (config.baseUnit == 0) revert InvalidBaseUnit();
+        if (config.priceFeed == address(0)) revert InvalidPriceFeed(config.priceFeed);
     }
 }

--- a/contracts/PriceOracle/PriceOracle.sol
+++ b/contracts/PriceOracle/PriceOracle.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.7;
+
+import { Ownable } from "../Ownable.sol";
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import { FullMath } from "../Uniswap/UniswapLib.sol";
+
+contract PriceOracle is Ownable {
+
+    /// @dev Configuration used to return the USD price for the associated cToken asset and base unit needed for formatting
+    /// There should be 1 TokenConfig object for each supported asset, passed in the constructor.
+    struct TokenConfig {
+        // The address of the Compound Token
+        address cToken;
+        // The number of smallest units of measurement in a single whole unit. (e.g. 1e18 for ETH)
+        uint256 baseUnit;
+        // Address of the feed used to retrieve the asset's price
+        address priceFeed;
+    }
+
+    /// @dev Mapping of cToken address to TokenConfig used to maintain the supported assets
+    mapping (address => TokenConfig) tokenConfigs;
+
+    /// @notice The event emitted when a new asset is added to the mapping
+    event PriceOracleAssetAdded(address indexed cToken, uint256 baseUnit, address priceFeed);
+
+    /// @notice The event emitted when the price feed for an existing config is updated
+    event PriceOracleAssetPriceFeedUpdated(address indexed cToken, address oldPriceFeed, address newPriceFeed);
+
+    /// @notice The event emitted when an asset is removed to the mapping
+    event PriceOracleAssetRemoved(address indexed cToken, uint256 baseUnit, address priceFeed);
+
+    /**
+     * @notice Construct a Price Oracle contract for a set of token configurations
+     * @param configs The token configurations that define which price feed and base unit to use for each asset
+     */
+    constructor(TokenConfig[] memory configs) {
+        // Populate token config mapping 
+        for (uint i = 0; i < configs.length; i++) {
+            TokenConfig memory config = configs[i];
+            validateTokenConfig(config);
+            // Check if duplicate configs were submitted for the same cToken
+            require(tokenConfigs[config.cToken].cToken == address(0), "Duplicate config for cToken found");
+            tokenConfigs[config.cToken] = config;
+        }
+    }
+
+    /**
+     * @notice Get the underlying price of a cToken, in the format expected by the Comptroller.
+     * @dev Implements the PriceOracle interface for Compound v2.
+     * @param cToken The cToken address for price retrieval
+     * @return Price denominated in USD for the given cToken address, in the format expected by the Comptroller.
+     */
+    function getUnderlyingPrice(address cToken)
+        external
+        view
+        returns (uint256)
+    {
+        TokenConfig memory config = tokenConfigs[cToken];
+        require(config.cToken != address(0), "Config not found for cToken");
+        // Initialize the aggregator to read the price from
+        AggregatorV3Interface priceFeed = AggregatorV3Interface(config.priceFeed);
+        // Retrieve decimals from feed for formatting
+        uint8 decimals = priceFeed.decimals();
+        // Fail safe check since this is an unrealistic scenario. The number of digits that the int256 answer can have naturally limits decimals
+        // but this protects against an erroneous uint8 values
+        require(decimals <= 72, "Decimals is too large to properly use in formatting the price");
+        // Retrieve price from feed
+        (
+            /* uint80 roundID */,
+            int256 answer,
+            /*uint startedAt*/,
+            /*uint timeStamp*/,
+            /*uint80 answeredInRound*/
+        ) = priceFeed.latestRoundData();
+        require(answer >= 0, "Price cannot be negative");
+        uint256 price = uint256(answer);
+
+        // Comptroller needs prices in the format: ${raw price} * 1e36 / baseUnit
+        // The baseUnit of an asset is the amount of the smallest denomination of that asset per whole.
+        // The decimals represent the number of decimals the price feed answer reports with. Supplied by the price feed.
+        // For example, the baseUnit of ETH is 1e18 and its price feed provides 8 decimal places
+        // We must scale the price by 1e(36 - decimals) / baseUnit
+
+        // Number of decimals determines whether the price needs to be multiplied or divided for scaling
+        // Handle the 2 scenarios separately to ensure a non-fractional scale value
+        if (decimals <= 36) {
+            // Decimals is always >=0 so the scale max value is 1e36 here and not at risk of overflowing
+            uint256 scale = 10 ** (36 - decimals);
+            return FullMath.mulDiv(price, scale, config.baseUnit);
+        } else {
+            // Decimals is capped at 72 by earlier validation so scale max value is 1e36 here and not at risk of overflowing
+            uint256 scale = 10 ** (decimals - 36);
+            // Divide price by scale and base unit separately
+            // Multiplying scale and base unit before dividing price could result in an overflow
+            uint256 scaledPrice = FullMath.mulDiv(price, 1, scale);
+            return FullMath.mulDiv(scaledPrice, 1, config.baseUnit);
+        }
+    }
+
+    /**
+     * @notice Retrieves the token config for a particular cToken address
+     * @param cToken The cToken address that the token config should be returned for
+     */
+    function getConfig(address cToken) external view returns (TokenConfig memory) {
+        TokenConfig memory config = tokenConfigs[cToken];
+        // Check if config exists for cToken
+        require(config.cToken != address(0), "Config for cToken does not exist");
+        return config;
+    }
+
+    /**
+     * @notice Adds a new token config to enable the contract to provide prices for a new asset
+     * @param config Token config struct that contains the info for a new asset configuration
+     */
+    function addConfig(TokenConfig calldata config) external onlyOwner {
+        // Check if duplicate configs were submitted for the same cToken
+        require(tokenConfigs[config.cToken].cToken == address(0), "Config for cToken already exists");
+        validateTokenConfig(config);
+
+        tokenConfigs[config.cToken] = config;
+        emit PriceOracleAssetAdded(config.cToken, config.baseUnit, config.priceFeed);
+    }
+
+    /**
+     * @notice Updates the price feed in the token config for a particular cToken
+     * @param cToken The cToken address that the config needs to be updated for
+     * @param priceFeed The address of the new price feed the config needs to be updated to
+     */
+    function updateConfigPriceFeed(address cToken, address priceFeed) external onlyOwner {
+        TokenConfig storage config = tokenConfigs[cToken];
+        // Check if config exists for cToken
+        require(config.cToken != address(0), "Config does not exist for cToken");
+        // Validate price feed
+        require(priceFeed != address(0), "Invalid new price feed address");
+        require(config.priceFeed != priceFeed, "Price feed address same as the existing one");
+
+        emit PriceOracleAssetPriceFeedUpdated(cToken, config.priceFeed, priceFeed);
+        config.priceFeed = priceFeed;
+    }
+
+    /**
+     * @notice Removes a token config to no longer support the asset
+     * @param cToken The cToken address that the token config should be removed for
+     */
+    function removeConfig(address cToken) external onlyOwner {
+        TokenConfig memory config = tokenConfigs[cToken];
+        // Check if config exists for cToken
+        require(config.cToken != address(0), "Config for cToken does not exist");
+
+        delete tokenConfigs[cToken];
+        emit PriceOracleAssetRemoved(cToken, config.baseUnit, config.priceFeed);
+    }
+
+    /**
+     * @notice Validates a token config
+     * @dev All fields are required
+     * @param config TokenConfig struct that needs to be validated
+     */
+    function validateTokenConfig(TokenConfig memory config) internal pure {
+        require(config.cToken != address(0), "Config missing cToken address");
+        // Dual check of field being present and being non-zero
+        require(config.baseUnit != 0, "Config either missing base unit or set to 0");
+        require(config.priceFeed != address(0), "Config missing price feed address");
+    }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-etherscan": "^2.1.6",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@openzeppelin/contracts": "4.9.0",
     "@typechain/ethers-v5": "^7.0.1",
     "@typechain/hardhat": "^2.3.0",
     "@types/chai": "^4.2.21",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@chainlink/contracts": "0.8.0",
     "@defi-wonderland/smock": "^2.0.3",
     "@nomiclabs/ethereumjs-vm": "^4.2.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
@@ -44,10 +45,12 @@
     "compile": "yarn hardhat compile",
     "deploy": "yarn hardhat run ./scripts/deploy-uav.js --network mainnet",
     "deploy-test": "yarn hardhat run ./scripts/deploy-uav.js --network hardhat",
+    "deploy-price-oracle": "yarn hardhat deploy-price-oracle --network mainnet",
     "verify-uav": "yarn hardhat verify-proposed-uav --network mainnet",
-    "verify": "yarn hardhat verify --network mainnet --constructor-args ./configuration/parameters.js",
+    "verify-price-oracle": "yarn hardhat verify-proposed-price-oracle --network mainnet",
+    "verify": "yarn hardhat verify --network mainnet --constructor-args",
     "verify-manual": "yarn hardhat manual-verify",
-    "transfer": "yarn hardhat transfer-ownership --network mainnet --uav",
+    "transfer": "yarn hardhat transfer-ownership --network mainnet --contract",
     "size-contracts": "yarn hardhat size-contracts"
   },
   "resolutions": {

--- a/tasks/price-oracle-tasks.ts
+++ b/tasks/price-oracle-tasks.ts
@@ -1,0 +1,124 @@
+import { ethers } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import parametersMainnet from "../configuration/parameters-price-oracle";
+
+// Ignore pairs that are not configured
+const IGNORED_PAIRS = ["cREP", "cFEI"];
+
+// Prints the price returned by the UAV and Price Oracle if not equal.
+// The price returned by the new contract can differ from the UAV without the Uniswap anchor
+// so a manually inspection of the prices are necessary
+export async function compareUavAndPriceOracle(
+  arg: {
+    production: string;
+    proposed: string;
+  },
+  hre: HardhatRuntimeEnvironment
+) {
+  const PRODUCTION_UAV_ADDR = arg.production;
+  const PROPOSED_PRICE_ORACLE_ADDR = arg.proposed;
+  const RPC_URL = process.env.MAINNET_URL;
+
+  const uavConfiguration = require("../configuration/parameters");
+  const uavABI = require("../artifacts/contracts/Uniswap/UniswapAnchoredView.sol/UniswapAnchoredView.json");
+  const priceOracleABI = require("../artifacts/contracts/PriceOracle/PriceOracle.sol/PriceOracle.json");
+
+  const cTokenABI = [
+    {
+      constant: true,
+      inputs: [],
+      name: "symbol",
+      outputs: [{ name: "", type: "string" }],
+      payable: false,
+      stateMutability: "view",
+      type: "function",
+    },
+  ];
+
+  const [_, __, tokenConfigs] = uavConfiguration;
+  if (!RPC_URL) {
+    throw new Error("RPC URL Cannot be empty");
+  }
+  const provider = new hre.ethers.providers.JsonRpcProvider(RPC_URL);
+  const prodUAV = new hre.ethers.Contract(
+    PRODUCTION_UAV_ADDR,
+    uavABI.abi,
+    provider
+  );
+  const proposedPriceOracle = new hre.ethers.Contract(
+    PROPOSED_PRICE_ORACLE_ADDR,
+    priceOracleABI.abi,
+    provider
+  );
+
+  for (const { cToken: cTokenAddr } of tokenConfigs) {
+    const checksumCTokenAddr = hre.ethers.utils.getAddress(cTokenAddr);
+    const cToken = new hre.ethers.Contract(
+      checksumCTokenAddr,
+      cTokenABI,
+      provider
+    );
+    const cTokenSymbol = await cToken.symbol();
+
+    if (IGNORED_PAIRS.indexOf(cTokenSymbol) !== -1) {
+      console.log(`Skipping check for ${cTokenSymbol}`);
+      continue;
+    }
+
+    console.log(
+      `Comparing prices for cToken ${cTokenSymbol} with address ${checksumCTokenAddr}`
+    );
+    const [prodUAVPrice, proposedPriceOraclePrice] = await Promise.all([
+      fetchUnderlyingPrice(prodUAV, checksumCTokenAddr, PRODUCTION_UAV_ADDR),
+      fetchUnderlyingPrice(
+        proposedPriceOracle,
+        checksumCTokenAddr,
+        PROPOSED_PRICE_ORACLE_ADDR
+      ),
+    ]);
+
+    if (!prodUAVPrice.eq(proposedPriceOraclePrice)) {
+      console.log(
+        `Prod UAV price: $${prodUAVPrice}. Proposed Price Oracle price: $${proposedPriceOraclePrice}`
+      );
+      continue;
+    }
+    console.log(
+      `Underlying prices for ${cTokenSymbol} match: $${proposedPriceOraclePrice}`
+    );
+  }
+}
+
+async function fetchUnderlyingPrice(
+  contract: ethers.Contract,
+  cTokenAddr: string,
+  proposedUAVAddr: string
+) {
+  try {
+    return await contract.getUnderlyingPrice(cTokenAddr);
+  } catch (e) {
+    const label =
+      contract.address === proposedUAVAddr ? "PROPOSED" : "PRODUCTION";
+    throw new Error(
+      `Call to getUnderlyingPrice(${cTokenAddr}) to ${label} at address ${contract.address} reverted!`
+    );
+  }
+}
+
+export async function deployPriceOracle(
+  _: any,
+  hre: HardhatRuntimeEnvironment
+) {
+  const PriceOracle = await hre.ethers.getContractFactory("PriceOracle");
+  let parameters;
+  if (hre.network.name === "mainnet" || hre.network.name === "hardhat") {
+    parameters = parametersMainnet;
+  } else {
+    throw Error("Invalid network");
+  }
+  const priceOracle = await PriceOracle.deploy(parameters, {
+    gasLimit: 9000000,
+  });
+  await priceOracle.deployed();
+  console.log("PriceOracle deployed to: ", priceOracle.address);
+}

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -1,0 +1,299 @@
+import { ethers } from "hardhat";
+import { expect, use } from "chai";
+import { MockContract, smock } from "@defi-wonderland/smock";
+import { exp, resetFork } from "./utils";
+import { PriceOracle, PriceOracle__factory } from "../types";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { deployMockContract } from "ethereum-waffle";
+
+// Chai matchers for mocked contracts
+use(smock.matchers);
+
+export const BigNumber = ethers.BigNumber;
+export type BigNumber = ReturnType<typeof BigNumber.from>;
+
+interface SetupOptions {
+  isMockedView: boolean;
+}
+
+const mockAggregatorAbi = [
+  {
+    inputs: [],
+    name: "latestRoundData",
+    outputs: [
+      { internalType: "uint80", name: "roundId", type: "uint80" },
+      { internalType: "int256", name: "answer", type: "int256" },
+      { internalType: "uint256", name: "startedAt", type: "uint256" },
+      { internalType: "uint256", name: "updatedAt", type: "uint256" },
+      { internalType: "uint80", name: "answeredInRound", type: "uint80" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "decimals",
+    outputs: [{ internalType: "uint8", name: "", type: "uint8" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+const configs = [
+  {
+    cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+    baseUnit: "1000000000000000000",
+    priceFeed: "",
+  },
+];
+
+async function setup({ isMockedView }: SetupOptions) {
+  const signers = await ethers.getSigners();
+  const deployer = signers[0];
+  const newOwner = signers[1];
+  const other = signers[2];
+
+  const mockedEthAggregator = await deployMockContract(
+    deployer,
+    mockAggregatorAbi
+  );
+  mockedEthAggregator.mock.latestRoundData.returns(0, 181217576125, 0, 0, 0);
+  mockedEthAggregator.mock.decimals.returns(8);
+  // Set config price feeds to mock aggregator
+  for (let config of configs) {
+    config.priceFeed = mockedEthAggregator.address;
+  }
+
+  let priceOracle: PriceOracle | MockContract<PriceOracle>;
+  if (isMockedView) {
+    const mockedPriceOracle = await smock.mock<PriceOracle__factory>(
+      "PriceOracle"
+    );
+    priceOracle = await mockedPriceOracle.deploy(configs);
+  } else {
+    priceOracle = await new PriceOracle__factory(deployer).deploy(configs);
+  }
+
+  return {
+    // aggregatorMap,
+    priceOracle,
+    signers,
+    deployer,
+    newOwner,
+    other,
+  };
+}
+
+describe("PriceOracle", () => {
+  // let priceFeed: MockChainlinkOCRAggregator;
+  let priceOracle: PriceOracle | MockContract<PriceOracle>;
+  let deployer: SignerWithAddress;
+  let newOwner: SignerWithAddress;
+  let other: SignerWithAddress;
+  // let aggregatorMap: Record<string, MockChainlinkOCRAggregator>;
+
+  beforeEach(async () => {
+    await resetFork();
+  });
+
+  describe("Ownable", () => {
+    beforeEach(async () => {
+      ({ priceOracle, deployer, newOwner, other } = await setup({
+        isMockedView: false,
+      }));
+    });
+
+    describe("transferOwnership", () => {
+      describe("when called by non owner", async () => {
+        it("reverts", async () => {
+          await expect(
+            priceOracle.connect(other).transferOwnership(newOwner.address)
+          ).to.be.revertedWith("Only callable by owner");
+        });
+      });
+
+      describe("when called by owner", () => {
+        describe("when transferring to self", () => {
+          it("reverts", async () => {
+            await expect(
+              priceOracle.connect(deployer).transferOwnership(deployer.address)
+            ).to.be.revertedWith("Cannot transfer to self");
+          });
+        });
+
+        describe("when transferring to another address", () => {
+          it("emit an event", async () => {
+            expect(
+              priceOracle.connect(deployer).transferOwnership(newOwner.address)
+            )
+              .to.emit(priceOracle, "OwnershipTransferRequested")
+              .withArgs(deployer.address, newOwner.address);
+          });
+        });
+      });
+    });
+
+    describe("acceptOwnership", () => {
+      beforeEach(async () => {
+        await priceOracle.connect(deployer).transferOwnership(newOwner.address);
+      });
+
+      describe("when called by an address that is not the new owner", () => {
+        it("reverts", async () => {
+          await expect(
+            priceOracle.connect(other).acceptOwnership()
+          ).to.be.revertedWith("Must be proposed owner");
+        });
+      });
+
+      describe("when accepted by an address that is the new proposed owner", () => {
+        it("correctly changes the contract ownership", async () => {
+          await priceOracle.connect(newOwner).acceptOwnership();
+          expect(await priceOracle.owner()).to.equal(newOwner.address);
+        });
+
+        it("emits an event", async () => {
+          await expect(priceOracle.connect(newOwner).acceptOwnership())
+            .to.emit(priceOracle, "OwnershipTransferred")
+            .withArgs(deployer.address, newOwner.address);
+        });
+      });
+    });
+  });
+
+  describe("getUnderlyingPrice", () => {
+    // everything must return 1e36 - underlying units
+
+    beforeEach(async () => {
+      ({ priceOracle, deployer } = await setup({
+        isMockedView: false,
+      }));
+    });
+
+    it("should return reported ETH price", async () => {
+      const ethCToken = "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5";
+      expect(await priceOracle.getUnderlyingPrice(ethCToken)).to.equal(
+        BigNumber.from("181217576125").mul(exp(1, 10))
+      );
+    });
+    it("should revert for missing config", async () => {
+      const invalidCToken = "0xF5DCe57282A584D2746FaF1593d3121Fcac444dC";
+      expect(priceOracle.getUnderlyingPrice(invalidCToken)).to.be.revertedWith(
+        "Config not found for cToken"
+      );
+    });
+  });
+  describe("addConfig", () => {
+    // everything must return 1e36 - underlying units
+
+    beforeEach(async () => {
+      ({ priceOracle, deployer } = await setup({
+        isMockedView: false,
+      }));
+    });
+
+    it("should return success", async () => {
+      const newConfig = {
+        cToken: "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
+        baseUnit: "1000000",
+        priceFeed: "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6",
+      };
+      expect(await priceOracle.addConfig(newConfig))
+        .to.emit(priceOracle, "PriceOracleAssetAdded")
+        .withArgs(newConfig.cToken, newConfig.baseUnit, newConfig.priceFeed);
+    });
+    it("should revert for duplicate config", async () => {
+      const dupeConfig = {
+        cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+        baseUnit: "1000000000000000000",
+        priceFeed: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+      };
+
+      expect(priceOracle.addConfig(dupeConfig)).to.be.revertedWith(
+        "Config for cToken already exists"
+      );
+    });
+    it("should revert for invalid config", async () => {
+      const invalidConfig = {
+        cToken: "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
+        baseUnit: "0",
+        priceFeed: "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6",
+      };
+
+      expect(priceOracle.addConfig(invalidConfig)).to.be.revertedWith(
+        "Config either missing base unit or set to 0"
+      );
+    });
+  });
+  describe("updateConfigPriceFeed", () => {
+    // everything must return 1e36 - underlying units
+
+    beforeEach(async () => {
+      ({ priceOracle, deployer } = await setup({
+        isMockedView: false,
+      }));
+    });
+
+    it("should return success", async () => {
+      const existingConfig = configs[0];
+      const newPriceFeed = "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6";
+      expect(
+        await priceOracle.updateConfigPriceFeed(
+          existingConfig.cToken,
+          newPriceFeed
+        )
+      )
+        .to.emit(priceOracle, "PriceOracleAssetPriceFeedUpdated")
+        .withArgs(
+          existingConfig.cToken,
+          existingConfig.priceFeed,
+          newPriceFeed
+        );
+    });
+    it("should revert for resetting same price feed", async () => {
+      const existingConfig = configs[0];
+
+      expect(
+        priceOracle.updateConfigPriceFeed(
+          existingConfig.cToken,
+          existingConfig.priceFeed
+        )
+      ).to.be.revertedWith("Price feed address same as the existing one");
+    });
+    it("should revert for missing config", async () => {
+      const missingCToken = "0x39AA39c021dfbaE8faC545936693aC917d5E7563";
+      const priceFeed = "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6";
+
+      expect(
+        priceOracle.updateConfigPriceFeed(missingCToken, priceFeed)
+      ).to.be.revertedWith("Config does not exist for cToken");
+    });
+  });
+  describe("removeConfig", () => {
+    // everything must return 1e36 - underlying units
+
+    beforeEach(async () => {
+      ({ priceOracle, deployer } = await setup({
+        isMockedView: false,
+      }));
+    });
+
+    it("should return success", async () => {
+      const existingConfig = configs[0];
+      expect(await priceOracle.removeConfig(existingConfig.cToken))
+        .to.emit(priceOracle, "PriceOracleAssetRemoved")
+        .withArgs(
+          existingConfig.cToken,
+          existingConfig.baseUnit,
+          existingConfig.priceFeed
+        );
+    });
+    it("should revert for missing config", async () => {
+      const missingCToken = "0x39AA39c021dfbaE8faC545936693aC917d5E7563";
+
+      expect(priceOracle.removeConfig(missingCToken)).to.be.revertedWith(
+        "Config for cToken does not exist"
+      );
+    });
+  });
+});

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -101,18 +101,22 @@ describe("PriceOracle", () => {
     describe("transferOwnership", () => {
       describe("when called by non owner", async () => {
         it("reverts", async () => {
-          await expect(
+          expect(
             priceOracle.connect(other).transferOwnership(newOwner.address)
-          ).to.be.revertedWith("Only callable by owner");
+          ).to.be.revertedWith("Ownable: caller is not the owner");
         });
       });
 
       describe("when called by owner", () => {
         describe("when transferring to self", () => {
-          it("reverts", async () => {
-            await expect(
-              priceOracle.connect(deployer).transferOwnership(deployer.address)
-            ).to.be.revertedWith("Cannot transfer to self");
+          it("is allowed", async () => {
+            expect(
+              await priceOracle
+                .connect(deployer)
+                .transferOwnership(deployer.address)
+            )
+              .to.emit(priceOracle, "OwnershipTransferStarted")
+              .withArgs(deployer.address, deployer.address);
           });
         });
 
@@ -135,9 +139,9 @@ describe("PriceOracle", () => {
 
       describe("when called by an address that is not the new owner", () => {
         it("reverts", async () => {
-          await expect(
+          expect(
             priceOracle.connect(other).acceptOwnership()
-          ).to.be.revertedWith("Must be proposed owner");
+          ).to.be.revertedWith("Ownable2Step: caller is not the new owner");
         });
       });
 

--- a/test/PriceOracleConfig.test.ts
+++ b/test/PriceOracleConfig.test.ts
@@ -1,0 +1,111 @@
+import { ethers } from "hardhat";
+import { expect, use } from "chai";
+import { PriceOracle__factory } from "../types";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { smock } from "@defi-wonderland/smock";
+
+use(smock.matchers);
+
+describe("PriceOracle", () => {
+  let signers: SignerWithAddress[];
+  let deployer: SignerWithAddress;
+
+  beforeEach(async () => {
+    signers = await ethers.getSigners();
+    deployer = signers[0];
+  });
+
+  describe("constructor", () => {
+    it("succeeds", async () => {
+      const configs = [
+        {
+          cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+          baseUnit: "1000000000000000000",
+          priceFeed: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+        },
+        {
+          cToken: "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
+          baseUnit: "1000000000000000000",
+          priceFeed: "0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9",
+        },
+      ];
+      const priceOracle = await new PriceOracle__factory(deployer).deploy(
+        configs
+      );
+      const config1 = configs[0];
+      const returnedConfig1 = await priceOracle.getConfig(config1.cToken);
+      expect(returnedConfig1.cToken).to.equal(config1.cToken);
+      expect(returnedConfig1.baseUnit).to.equal(config1.baseUnit);
+      expect(returnedConfig1.priceFeed).to.equal(config1.priceFeed);
+
+      const config2 = configs[1];
+      const returnedConfig2 = await priceOracle.getConfig(config2.cToken);
+      expect(returnedConfig2.cToken).to.equal(config2.cToken);
+      expect(returnedConfig2.baseUnit).to.equal(config2.baseUnit);
+      expect(returnedConfig2.priceFeed).to.equal(config2.priceFeed);
+
+      const invalidCToken = "0x39AA39c021dfbaE8faC545936693aC917d5E7563";
+      expect(priceOracle.getConfig(invalidCToken)).to.be.revertedWith(
+        "Config for cToken does not exist"
+      );
+    });
+    it("reverts if repeating configs", async () => {
+      const repeatConfigs = [
+        {
+          cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+          baseUnit: "1000000000000000000",
+          priceFeed: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+        },
+        {
+          cToken: "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
+          baseUnit: "1000000000000000000",
+          priceFeed: "0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9",
+        },
+        {
+          cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+          baseUnit: "1000000",
+          priceFeed: "0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
+        },
+      ];
+      await expect(
+        new PriceOracle__factory(deployer).deploy(repeatConfigs)
+      ).to.be.revertedWith("Duplicate config for cToken found");
+    });
+    it("reverts if missing cToken", async () => {
+      const invalidConfigs = [
+        {
+          cToken: "0x0000000000000000000000000000000000000000",
+          baseUnit: "1000000000000000000",
+          priceFeed: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+        },
+      ];
+      await expect(
+        new PriceOracle__factory(deployer).deploy(invalidConfigs)
+      ).to.be.revertedWith("Config missing cToken address");
+    });
+    it("reverts if baseUnit is 0", async () => {
+      const invalidConfigs = [
+        {
+          cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+          baseUnit: "0",
+          priceFeed: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+        },
+      ];
+      await expect(
+        new PriceOracle__factory(deployer).deploy(invalidConfigs)
+      ).to.be.revertedWith("Config either missing base unit or set to 0");
+    });
+    it("reverts if missing priceFeed", async () => {
+      const invalidConfigs = [
+        {
+          cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+          baseUnit: "1000000000000000000",
+          priceFeed: "0x0000000000000000000000000000000000000000",
+        },
+      ];
+      await expect(
+        new PriceOracle__factory(deployer).deploy(invalidConfigs)
+      ).to.be.revertedWith("Config missing price feed address");
+    });
+  });
+});

--- a/test/PriceOracleConfig.test.ts
+++ b/test/PriceOracleConfig.test.ts
@@ -46,7 +46,7 @@ describe("PriceOracle", () => {
 
       const invalidCToken = "0x39AA39c021dfbaE8faC545936693aC917d5E7563";
       expect(priceOracle.getConfig(invalidCToken)).to.be.revertedWith(
-        "Config for cToken does not exist"
+        "ConfigNotFound"
       );
     });
     it("reverts if repeating configs", async () => {
@@ -69,7 +69,7 @@ describe("PriceOracle", () => {
       ];
       await expect(
         new PriceOracle__factory(deployer).deploy(repeatConfigs)
-      ).to.be.revertedWith("Duplicate config for cToken found");
+      ).to.be.revertedWith("DuplicateConfig");
     });
     it("reverts if missing cToken", async () => {
       const invalidConfigs = [
@@ -81,7 +81,7 @@ describe("PriceOracle", () => {
       ];
       await expect(
         new PriceOracle__factory(deployer).deploy(invalidConfigs)
-      ).to.be.revertedWith("Config missing cToken address");
+      ).to.be.revertedWith("MissingCTokenAddress");
     });
     it("reverts if baseUnit is 0", async () => {
       const invalidConfigs = [
@@ -93,7 +93,7 @@ describe("PriceOracle", () => {
       ];
       await expect(
         new PriceOracle__factory(deployer).deploy(invalidConfigs)
-      ).to.be.revertedWith("Config either missing base unit or set to 0");
+      ).to.be.revertedWith("InvalidBaseUnit");
     });
     it("reverts if missing priceFeed", async () => {
       const invalidConfigs = [
@@ -105,7 +105,7 @@ describe("PriceOracle", () => {
       ];
       await expect(
         new PriceOracle__factory(deployer).deploy(invalidConfigs)
-      ).to.be.revertedWith("Config missing price feed address");
+      ).to.be.revertedWith("InvalidPriceFeed");
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "resolveJsonModule": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,6 +188,16 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@chainlink/contracts@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@chainlink/contracts/-/contracts-0.8.0.tgz#4050c83c8b1603ffb0fd6ab99f1d9ea9db2c37de"
+  integrity sha512-nUv1Uxw5Mn92wgLs2bgPYmo8hpdQ3s9jB/lcbdU0LmNOVu0hbfmouVnqwRLa28Ll50q6GczUA+eO0ikNIKLZsA==
+  dependencies:
+    "@eth-optimism/contracts" "^0.5.21"
+    "@openzeppelin/contracts" "~4.3.3"
+    "@openzeppelin/contracts-upgradeable-4.7.3" "npm:@openzeppelin/contracts-upgradeable@v4.7.3"
+    "@openzeppelin/contracts-v0.7" "npm:@openzeppelin/contracts@v3.4.2"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -234,6 +244,37 @@
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.2.4.tgz#c10fe28bf5efbf49bff4666d909aed0265efbc89"
   integrity sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==
+
+"@eth-optimism/contracts@^0.5.21":
+  version "0.5.40"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.5.40.tgz#d13a04a15ea947a69055e6fc74d87e215d4c936a"
+  integrity sha512-MrzV0nvsymfO/fursTB7m/KunkPsCndltVgfdHaT1Aj5Vi6R/doKIGGkOofHX+8B6VMZpuZosKCMQ5lQuqjt8w==
+  dependencies:
+    "@eth-optimism/core-utils" "0.12.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+
+"@eth-optimism/core-utils@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.12.0.tgz#6337e4599a34de23f8eceb20378de2a2de82b0ea"
+  integrity sha512-qW+7LZYCz7i8dRa7SRlUKIo1VBU8lvN0HeXCxJR+z+xtMzMQpPds20XJNCMclszxYQHkXY00fOT6GvFw9ZL6nw==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/contracts" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/providers" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bufio "^1.0.7"
+    chai "^4.3.4"
 
 "@ethereum-waffle/chai@^3.4.0":
   version "3.4.0"
@@ -388,6 +429,21 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
+"@ethersproject/abi@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
+  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@ethersproject/abstract-provider@5.4.1", "@ethersproject/abstract-provider@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz#e404309a29f771bd4d28dbafadcaa184668c2a6e"
@@ -401,6 +457,19 @@
     "@ethersproject/transactions" "^5.4.0"
     "@ethersproject/web" "^5.4.0"
 
+"@ethersproject/abstract-provider@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
+  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+
 "@ethersproject/abstract-signer@5.4.1", "@ethersproject/abstract-signer@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz#e4e9abcf4dd4f1ba0db7dff9746a5f78f355ea81"
@@ -411,6 +480,17 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
+
+"@ethersproject/abstract-signer@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
+  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
 
 "@ethersproject/address@5.4.0", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.0.4", "@ethersproject/address@^5.4.0":
   version "5.4.0"
@@ -423,12 +503,30 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/rlp" "^5.4.0"
 
+"@ethersproject/address@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
+  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+
 "@ethersproject/base64@5.4.0", "@ethersproject/base64@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.4.0.tgz#7252bf65295954c9048c7ca5f43e5c86441b2a9a"
   integrity sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==
   dependencies:
     "@ethersproject/bytes" "^5.4.0"
+
+"@ethersproject/base64@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
+  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
 
 "@ethersproject/basex@5.4.0", "@ethersproject/basex@^5.4.0":
   version "5.4.0"
@@ -437,6 +535,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
+
+"@ethersproject/basex@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.7.0.tgz#97034dc7e8938a8ca943ab20f8a5e492ece4020b"
+  integrity sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
 
 "@ethersproject/bignumber@5.4.1", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.4.0":
   version "5.4.1"
@@ -447,6 +553,15 @@
     "@ethersproject/logger" "^5.4.0"
     bn.js "^4.11.9"
 
+"@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@5.4.0", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
@@ -454,12 +569,26 @@
   dependencies:
     "@ethersproject/logger" "^5.4.0"
 
+"@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/constants@5.4.0", "@ethersproject/constants@^5.0.4", "@ethersproject/constants@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.4.0.tgz#ee0bdcb30bf1b532d2353c977bf2ef1ee117958a"
   integrity sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==
   dependencies:
     "@ethersproject/bignumber" "^5.4.0"
+
+"@ethersproject/constants@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
+  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
 
 "@ethersproject/contracts@5.4.1":
   version "5.4.1"
@@ -477,6 +606,22 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/transactions" "^5.4.0"
 
+"@ethersproject/contracts@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
+  integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+
 "@ethersproject/hash@5.4.0", "@ethersproject/hash@^5.0.4", "@ethersproject/hash@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.4.0.tgz#d18a8e927e828e22860a011f39e429d388344ae0"
@@ -490,6 +635,21 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/hash@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
+  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@ethersproject/hdnode@5.4.0", "@ethersproject/hdnode@^5.4.0":
   version "5.4.0"
@@ -536,10 +696,23 @@
     "@ethersproject/bytes" "^5.4.0"
     js-sha3 "0.5.7"
 
+"@ethersproject/keccak256@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
+  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.4.1", "@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.1.tgz#503bd33683538b923c578c07d1c2c0dd18672054"
   integrity sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==
+
+"@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
 "@ethersproject/networks@5.4.2", "@ethersproject/networks@^5.4.0":
   version "5.4.2"
@@ -547,6 +720,13 @@
   integrity sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==
   dependencies:
     "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/networks@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
+  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/pbkdf2@5.4.0", "@ethersproject/pbkdf2@^5.4.0":
   version "5.4.0"
@@ -562,6 +742,13 @@
   integrity sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==
   dependencies:
     "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/properties@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
+  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/providers@5.4.5":
   version "5.4.5"
@@ -588,6 +775,32 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@^5.7.0":
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
+  integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.4.0", "@ethersproject/random@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.4.0.tgz#9cdde60e160d024be39cc16f8de3b9ce39191e16"
@@ -595,6 +808,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/random@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
+  integrity sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/rlp@5.4.0", "@ethersproject/rlp@^5.4.0":
   version "5.4.0"
@@ -604,6 +825,14 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
 
+"@ethersproject/rlp@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
+  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/sha2@5.4.0", "@ethersproject/sha2@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.4.0.tgz#c9a8db1037014cbc4e9482bd662f86c090440371"
@@ -611,6 +840,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
+  integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@5.4.0", "@ethersproject/signing-key@^5.4.0":
@@ -622,6 +860,18 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
     bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
+  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    bn.js "^5.2.1"
     elliptic "6.5.4"
     hash.js "1.1.7"
 
@@ -645,6 +895,15 @@
     "@ethersproject/constants" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
 
+"@ethersproject/strings@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
+  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/transactions@5.4.0", "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.4.0.tgz#a159d035179334bd92f340ce0f77e83e9e1522e0"
@@ -659,6 +918,21 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/rlp" "^5.4.0"
     "@ethersproject/signing-key" "^5.4.0"
+
+"@ethersproject/transactions@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
+  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
 
 "@ethersproject/units@5.4.0":
   version "5.4.0"
@@ -700,6 +974,17 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/web@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
+  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
+  dependencies:
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@ethersproject/wordlists@5.4.0", "@ethersproject/wordlists@^5.4.0":
   version "5.4.0"
@@ -928,10 +1213,25 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin/contracts-upgradeable-4.7.3@npm:@openzeppelin/contracts-upgradeable@v4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz#f1d606e2827d409053f3e908ba4eb8adb1dd6995"
+  integrity sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==
+
+"@openzeppelin/contracts-v0.7@npm:@openzeppelin/contracts@v3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2.tgz#d81f786fda2871d1eb8a8c5a73e455753ba53527"
+  integrity sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==
+
 "@openzeppelin/contracts@3.4.1-solc-0.7-2":
   version "3.4.1-solc-0.7-2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
+
+"@openzeppelin/contracts@~4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.3.tgz#ff6ee919fc2a1abaf72b22814bfb72ed129ec137"
+  integrity sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
@@ -2665,6 +2965,11 @@ bn.js@^5.1.3:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
+
 body-parser@1.19.0, body-parser@^1.16.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
@@ -2883,6 +3188,11 @@ bufferutil@^4.0.1:
   integrity sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==
   dependencies:
     node-gyp-build "^4.2.0"
+
+bufio@^1.0.7:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.2.1.tgz#8d4ab3ddfcd5faa90f996f922f9397d41cbaf2de"
+  integrity sha512-9oR3zNdupcg/Ge2sSHQF3GX+kmvL/fTPvD0nd5AGLq8SjUYnTz+SlFjK/GXidndbZtIj+pVKXiWeR9w6e9wKCA==
 
 bytes@3.1.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,6 +1228,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
+"@openzeppelin/contracts@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.0.tgz#683f33b6598970051bc5f0806fd8660da9e018dd"
+  integrity sha512-DUP74AFGKlic2sQb/CmgrN2aUPMFGxRrmCTUxLHsiU2RzwWqVuMPZBxiAyvlff6Pea77uylAX6B5x9W6evEbhA==
+
 "@openzeppelin/contracts@~4.3.3":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.3.tgz#ff6ee919fc2a1abaf72b22814bfb72ed129ec137"


### PR DESCRIPTION
## Context
The Compound UAV relies on Uniswap prices to anchor price updates from Chainlink. During high market fluctuation, this has caused valid price updates to get blocked due to inaccurate prices from Uniswap. The new PriceOracle contract would return prices directly from Chainlink feeds without any dependency on Uniswap. This change would provide Compound v2 with more accurate prices even when there's market volatility.

## Description
- Adds a new price oracle contract that reads Chainlink price feeds directly.
  - Includes feature to add, update, and remove configs without requiring redeployment
  - Trims down the configs to just cToken address, base units, and price feed address
- Cleans out configs for the deprecated markets: `FEI`, `REP`, `SAI`, `WBTC` (does not include `WBTCv2`)
- Provides 8 decimal places of precision as opposed to 6 from the UAV contract