### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: "16"
       - name: Checkout the repo
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: "16"
       - name: Checkout the repo
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: "16"
       - name: Checkout the repo

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
       - name: Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         env:
           cache-name: yarn-cache
         with:
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
       - name: Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         env:
           cache-name: yarn-cache
         with:
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
       - name: Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         env:
           cache-name: yarn-cache
         with:

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: "16"
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Yarn cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         env:
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: "16"
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Yarn cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         env:
@@ -78,7 +78,7 @@ jobs:
         with:
           node-version: "16"
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Yarn cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         env:


### PR DESCRIPTION
## What

Updating Github Action references in all workflows.

## Why

Github Actions node16 deprecation. See [blog post (github.blog)](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
> Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). As a result we have started the deprecation process of Node16 for GitHub Actions. We plan to migrate all actions to run on Node20 by Spring 2024.
> Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 13th of May.

## Notes

RE-2531


```
[ERROR] Deprecated dependencies found (9)!!
solidity.yml -> solidity_coverage -> actions/cache@v2 -> node12
solidity.yml -> solidity_coverage -> actions/checkout@v2 -> node12
solidity.yml -> solidity_coverage -> actions/setup-node@v2 -> node12
solidity.yml -> solidity_test -> actions/cache@v2 -> node12
solidity.yml -> solidity_test -> actions/checkout@v2 -> node12
solidity.yml -> solidity_test -> actions/setup-node@v2 -> node12
solidity.yml -> verify_proposed_uav -> actions/cache@v2 -> node12
solidity.yml -> verify_proposed_uav -> actions/checkout@v2 -> node12
solidity.yml -> verify_proposed_uav -> actions/setup-node@v2 -> node12
```