### PR TITLE
Remove restrictions on 0 underlying decimal config

### DIFF
--- a/contracts/PriceOracle/PriceOracle.sol
+++ b/contracts/PriceOracle/PriceOracle.sol
@@ -71,9 +71,6 @@ contract PriceOracle is Ownable2Step {
     /// @notice cToken address for config not provided
     error MissingCTokenAddress();
 
-    /// @notice UnderlyingAssetDecimals is missing or set to value 0
-    error InvalidUnderlyingAssetDecimals();
-
     /// @notice Sum of price feed's decimals and underlyingAssetDecimals is greater than MAX_DECIMALS
     /// @param decimals Sum of the feed's decimals and underlying asset decimals
     error FormattingDecimalsTooHigh(uint16 decimals);
@@ -140,7 +137,7 @@ contract PriceOracle is Ownable2Step {
     {
         TokenConfig memory config = tokenConfigs[cToken];
         // Check if config exists for cToken
-        if (config.underlyingAssetDecimals == 0) revert ConfigNotFound(cToken);
+        if (config.priceFeed == address(0) && config.fixedPrice == 0) revert ConfigNotFound(cToken);
         // Return fixed price if set
         if (config.fixedPrice != 0) return config.fixedPrice;
         // Initialize the aggregator to read the price from
@@ -180,7 +177,7 @@ contract PriceOracle is Ownable2Step {
     function getConfig(address cToken) external view returns (TokenConfig memory) {
         TokenConfig memory config = tokenConfigs[cToken];
         // Check if config exists for cToken
-        if (config.underlyingAssetDecimals == 0) revert ConfigNotFound(cToken);
+        if (config.priceFeed == address(0) && config.fixedPrice == 0) revert ConfigNotFound(cToken);
         return config;
     }
 
@@ -203,7 +200,7 @@ contract PriceOracle is Ownable2Step {
     function updateConfigPriceFeed(address cToken, address priceFeed) external onlyOwner {
         TokenConfig memory config = tokenConfigs[cToken];
         // Check if config exists for cToken
-        if (config.underlyingAssetDecimals == 0) revert ConfigNotFound(cToken);
+        if (config.priceFeed == address(0) && config.fixedPrice == 0) revert ConfigNotFound(cToken);
         // Validate price feed
         if (priceFeed == address(0)) revert InvalidPriceFeed(priceFeed);
         // Check if existing price feed is the same as the new one sent
@@ -229,7 +226,7 @@ contract PriceOracle is Ownable2Step {
     function updateConfigFixedPrice(address cToken, uint256 fixedPrice) external onlyOwner {
         TokenConfig memory config = tokenConfigs[cToken];
         // Check if config exists for cToken
-        if (config.underlyingAssetDecimals == 0) revert ConfigNotFound(cToken);
+        if (config.priceFeed == address(0) && config.fixedPrice == 0) revert ConfigNotFound(cToken);
         // Validate fixed price
         if (fixedPrice == 0) revert InvalidFixedPrice(fixedPrice);
         // Check if existing fixed price is the same as the new one sent
@@ -252,7 +249,7 @@ contract PriceOracle is Ownable2Step {
     function removeConfig(address cToken) external onlyOwner {
         TokenConfig memory config = tokenConfigs[cToken];
         // Check if config exists for cToken
-        if (config.underlyingAssetDecimals == 0) revert ConfigNotFound(cToken);
+        if (config.priceFeed == address(0) && config.fixedPrice == 0) revert ConfigNotFound(cToken);
         delete tokenConfigs[cToken];
         emit PriceOracleAssetRemoved(cToken, config.underlyingAssetDecimals, config.priceFeed, config.fixedPrice);
     }
@@ -265,14 +262,13 @@ contract PriceOracle is Ownable2Step {
     function _validateTokenConfig(LoadConfig memory config) internal view {
         // Check if cToken is zero address
         if (config.cToken == address(0)) revert MissingCTokenAddress();
-        // Check if underlyingAssetDecimals exists and non-zero
-        if (config.underlyingAssetDecimals == 0) revert InvalidUnderlyingAssetDecimals();
         // Check if both price feed and fixed price are empty
         if (config.priceFeed == address(0) && config.fixedPrice == 0) revert InvalidPriceConfigs(config.priceFeed, config.fixedPrice);
         // Check if both price feed and fixed price are set
         if (config.priceFeed != address(0) && config.fixedPrice != 0) revert InvalidPriceConfigs(config.priceFeed, config.fixedPrice);
+        TokenConfig memory existingConfig = tokenConfigs[config.cToken];
         // Check if duplicate configs were submitted for the same cToken
-        if (tokenConfigs[config.cToken].underlyingAssetDecimals != 0) revert DuplicateConfig(config.cToken);
+        if (existingConfig.priceFeed != address(0) || existingConfig.fixedPrice != 0) revert DuplicateConfig(config.cToken);
         if (config.priceFeed != address(0)) {
             _validateDecimals(config.priceFeed, config.underlyingAssetDecimals);
         }

--- a/contracts/PriceOracle/PriceOracle.sol
+++ b/contracts/PriceOracle/PriceOracle.sol
@@ -256,7 +256,7 @@ contract PriceOracle is Ownable2Step {
 
     /**
      * @notice Validates a token config and confirms one for the cToken does not already exist in mapping
-     * @dev All fields are required
+     * @dev All fields are required. Underlying asset decimals is allowed to be 0 to support 0 decimal ERC20 tokens.
      * @param config TokenConfig struct that needs to be validated
      */
     function _validateTokenConfig(LoadConfig memory config) internal view {

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -277,11 +277,6 @@ describe("PriceOracle", () => {
         );
     });
     it("should return success with fixed price", async () => {
-      const mockedEthAggregator = await deployMockContract(
-        deployer,
-        mockAggregatorAbi
-      );
-      await mockedEthAggregator.mock.decimals.returns(8);
       const newConfig: TokenConfig = {
         cToken: "0x944DD1c7ce133B75880CeE913d513f8C07312393",
         underlyingAssetDecimals: "18",
@@ -345,26 +340,27 @@ describe("PriceOracle", () => {
         "InvalidPriceConfigs"
       );
     });
-    it("should revert for 0 underlyingAssetDecimals in config", async () => {
-      const invalidConfigWithPriceFeed: TokenConfig = {
+    it("should succeed for 0 underlyingAssetDecimals in config", async () => {
+      const mockedEthAggregator = await deployMockContract(
+        deployer,
+        mockAggregatorAbi
+      );
+      await mockedEthAggregator.mock.decimals.returns(8);
+      const zeroDecimalConfig: TokenConfig = {
         cToken: "0x041171993284df560249B57358F931D9eB7b925D",
         underlyingAssetDecimals: "0",
-        priceFeed: "0x09023c0da49aaf8fc3fa3adf34c6a7016d38d5e3",
+        priceFeed: mockedEthAggregator.address,
         fixedPrice: "0",
       };
-      const invalidConfigWithFixedPrice: TokenConfig = {
-        cToken: "0x041171993284df560249B57358F931D9eB7b925D",
-        underlyingAssetDecimals: "0",
-        priceFeed: zeroAddress,
-        fixedPrice: "1000",
-      };
 
-      await expect(
-        priceOracle.addConfig(invalidConfigWithPriceFeed)
-      ).to.be.revertedWith("InvalidUnderlyingAssetDecimals");
-      await expect(
-        priceOracle.addConfig(invalidConfigWithFixedPrice)
-      ).to.be.revertedWith("InvalidUnderlyingAssetDecimals");
+      expect(await priceOracle.addConfig(zeroDecimalConfig))
+        .to.emit(priceOracle, "PriceOracleAssetAdded")
+        .withArgs(
+          zeroDecimalConfig.cToken,
+          0,
+          zeroDecimalConfig.priceFeed,
+          zeroDecimalConfig.fixedPrice
+        );
     });
     it("should revert for underlyingAssetDecimals too high in config", async () => {
       const mockedEthAggregator = await deployMockContract(

--- a/test/PriceOracleConfig.test.ts
+++ b/test/PriceOracleConfig.test.ts
@@ -7,6 +7,7 @@ import { TokenConfig } from "../configuration/parameters-price-oracle";
 import { resetFork } from "./utils";
 import { deployMockContract } from "ethereum-waffle";
 import { mockAggregatorAbi } from "./PriceOracle.test";
+import { BigNumber } from "ethers";
 
 use(smock.matchers);
 
@@ -48,23 +49,54 @@ describe("PriceOracle", () => {
           priceFeed: zeroAddress,
           fixedPrice: "15544520000000000000",
         },
+        // 0 underlying decimal
+        {
+          cToken: "0xccf4429db6322d5c611ee964527d42e5d685dd6a",
+          underlyingAssetDecimals: "0",
+          priceFeed: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+          fixedPrice: "0",
+        },
       ];
       const priceOracle = await new PriceOracle__factory(deployer).deploy(
         configs
       );
+      // Validate config 1
       const config1 = configs[0];
       const returnedConfig1 = await priceOracle.getConfig(config1.cToken);
       expect(returnedConfig1.underlyingAssetDecimals).to.equal(
         Number(config1.underlyingAssetDecimals)
       );
       expect(returnedConfig1.priceFeed).to.equal(config1.priceFeed);
+      expect(returnedConfig1.fixedPrice).to.equal(0);
 
+      // Validate config 2
       const config2 = configs[1];
       const returnedConfig2 = await priceOracle.getConfig(config2.cToken);
       expect(returnedConfig2.underlyingAssetDecimals).to.equal(
         Number(config2.underlyingAssetDecimals)
       );
       expect(returnedConfig2.priceFeed).to.equal(config2.priceFeed);
+      expect(returnedConfig2.fixedPrice).to.equal(0);
+
+      // Validate config 3
+      const config3 = configs[2];
+      const returnedConfig3 = await priceOracle.getConfig(config3.cToken);
+      expect(returnedConfig3.underlyingAssetDecimals).to.equal(
+        Number(config3.underlyingAssetDecimals)
+      );
+      expect(returnedConfig3.priceFeed).to.equal(config3.priceFeed);
+      expect(returnedConfig3.fixedPrice).to.equal(
+        BigNumber.from(config3.fixedPrice)
+      );
+
+      // Validate config 4
+      const config4 = configs[3];
+      const returnedConfig4 = await priceOracle.getConfig(config4.cToken);
+      expect(returnedConfig4.underlyingAssetDecimals).to.equal(
+        Number(config4.underlyingAssetDecimals)
+      );
+      expect(returnedConfig4.priceFeed).to.equal(config4.priceFeed);
+      expect(returnedConfig4.fixedPrice).to.equal(0);
 
       const invalidCToken = "0x39AA39c021dfbaE8faC545936693aC917d5E7563";
       expect(priceOracle.getConfig(invalidCToken)).to.be.revertedWith(
@@ -114,19 +146,6 @@ describe("PriceOracle", () => {
       await expect(
         new PriceOracle__factory(deployer).deploy(invalidConfigs)
       ).to.be.revertedWith("MissingCTokenAddress");
-    });
-    it("reverts if underlyingAssetDecimals is 0", async () => {
-      const invalidConfigs: TokenConfig[] = [
-        {
-          cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
-          underlyingAssetDecimals: "0",
-          priceFeed: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
-          fixedPrice: "0",
-        },
-      ];
-      await expect(
-        new PriceOracle__factory(deployer).deploy(invalidConfigs)
-      ).to.be.revertedWith("InvalidUnderlyingAssetDecimals");
     });
     it("reverts if feed decimals are too high", async () => {
       const mockedEthAggregator = await deployMockContract(


### PR DESCRIPTION
ERC20 assets with 0 decimal or unset decimals (defaults to 0) exist. This change enables the `PriceOracle` contract to accept assets with 0 decimals. There is a chance that Compound would want to integrate one of these although those chances are slim. This change removes the arbitrary restriction on the underlying asset's decimal having to be non-zero.