### PR TITLE
Add min precision validation to underlying asset decimals

### DIFF
--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -362,15 +362,31 @@ describe("PriceOracle", () => {
           zeroDecimalConfig.fixedPrice
         );
     });
-    it("should revert for underlyingAssetDecimals too high in config", async () => {
+    it("should revert for underlyingAssetDecimals too high for min precision", async () => {
       const mockedEthAggregator = await deployMockContract(
         deployer,
         mockAggregatorAbi
       );
       await mockedEthAggregator.mock.decimals.returns(8);
+      const invalidConfigWithPriceFeed: TokenConfig = {
+        cToken: "0x80a2AE356fc9ef4305676f7a3E2Ed04e12C33946",
+        underlyingAssetDecimals: "31",
+        priceFeed: mockedEthAggregator.address,
+        fixedPrice: "0",
+      };
+      await expect(
+        priceOracle.addConfig(invalidConfigWithPriceFeed)
+      ).to.be.revertedWith("InvalidUnderlyingAssetDecimals");
+    });
+    it("should revert for formatting decimals too high", async () => {
+      const mockedEthAggregator = await deployMockContract(
+        deployer,
+        mockAggregatorAbi
+      );
+      await mockedEthAggregator.mock.decimals.returns(45);
       const invalidConfig: TokenConfig = {
         cToken: "0x041171993284df560249B57358F931D9eB7b925D",
-        underlyingAssetDecimals: "75",
+        underlyingAssetDecimals: "30",
         priceFeed: mockedEthAggregator.address,
         fixedPrice: "0",
       };

--- a/test/PriceOracleConfig.test.ts
+++ b/test/PriceOracleConfig.test.ts
@@ -103,6 +103,19 @@ describe("PriceOracle", () => {
         "ConfigNotFound"
       );
     });
+    it("reverts if underlyingAssetDecimals is too high", async () => {
+      const invalidConfigs: TokenConfig[] = [
+        {
+          cToken: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+          underlyingAssetDecimals: "31",
+          priceFeed: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+          fixedPrice: "0",
+        },
+      ];
+      await expect(
+        new PriceOracle__factory(deployer).deploy(invalidConfigs)
+      ).to.be.revertedWith("InvalidUnderlyingAssetDecimals");
+    });
     it("reverts if repeating configs", async () => {
       const repeatConfigs: TokenConfig[] = [
         {


### PR DESCRIPTION
If the `underlyingAssetDecimals` config is left unbound, an asset with a large underlying decimal could cause its price to lose precision due to the expected format `rawPrice * 1e(36 - feedDecimals - underlyingAssetDecimals)`. If minimum precision is set to 6, `underlyingAssetDecimals` set to anything above 30 would require formatting to shave off digits of precision from the end. To counter this, `underlyingAssetDecimals` is validated against the `36 - minPrecision` where `minPrecision` is set to 6 to match the Compound UAV behavior.